### PR TITLE
feat: add profile and routing configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,153 @@
 version = 4
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "gh-mcp-router"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "A local-first identity and routing layer for the official GitHub MCP Server"
 license = "MIT"
 
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+
 [lib]
 name = "gh_mcp_router"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -316,10 +316,26 @@ gh-mcp-router profiles
 gh-mcp-router route <owner/repo>
 gh-mcp-router explain <owner/repo>
 gh-mcp-router doctor
+gh-mcp-router validate --config PATH
 gh-mcp-router serve
 ```
 
-These commands are part of the v0.1 roadmap and are not available yet.
+## Configuration
+
+The default configuration is `$XDG_CONFIG_HOME/gh-mcp-router/config.yaml` on
+Unix-like systems, or `~/.config/gh-mcp-router/config.yaml` when
+`XDG_CONFIG_HOME` is not set. Windows uses `%APPDATA%/gh-mcp-router/config.yaml`.
+Use `--config PATH` to select another YAML or JSON file.
+
+The complete v0.1 schema is checked in at
+[`examples/config.example.yaml`](examples/config.example.yaml). It supports
+named credential references, optional per-profile `GH_CONFIG_DIR` and host
+isolation, ordered exact/glob repository, owner, and host routes, a default
+profile, and separate read/write ambiguity policies. Unknown fields are
+rejected, including token/PAT fields.
+
+The remaining commands are part of the v0.1 roadmap and are not available yet;
+`validate` is available now for checking configuration files.
 
 ### `init`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,15 +30,15 @@ Official GitHub MCP Server
 GitHub
 ```
 
-The current crate establishes these boundaries only. Discovery, routing
-evaluation, credential providers, upstream sessions, and MCP forwarding are
-planned work in later features.
+The configuration boundary now parses and validates profiles and ordered route
+rules before later services start. Discovery, routing evaluation, credential
+providers, upstream sessions, and MCP forwarding remain separate concerns.
 
 ## Module responsibilities
 
 | Module | Responsibility | Explicit non-responsibilities |
 | --- | --- | --- |
-| `config` | Profile and route-rule models | Configuration-file parsing |
+| `config` | Serializable profile/route models, parsing, path expansion, and validation | Credential retrieval or routing evaluation |
 | `context` | Normalized repository identity | Git remote or MCP root discovery |
 | `routing` | Pure routing decision domain | Credential retrieval, API calls, CLI state |
 | `credentials` | Credential references and provider interface | GitHub CLI discovery or token retrieval |
@@ -77,15 +77,15 @@ capabilities rather than duplicate their definitions.
 - Ambiguous write operations will eventually fail closed rather than guess an
   identity.
 
-These are design principles. The behavior marked as planned will be added by
-the feature that owns it; this foundation does not perform credential
-discovery, repository inference, routing evaluation, or MCP proxying.
+These are design principles. This feature validates configuration and expands
+safe path references, but does not perform credential discovery, repository
+inference, routing evaluation, or MCP proxying.
 
 ## Planned feature ownership
 
 The next features add behavior behind the boundaries established here:
 
-- configuration parsing (`#3`)
+- configuration parsing and validation (`#3`, implemented)
 - GitHub CLI credential discovery (`#4`)
 - deterministic routing evaluation (`#5`)
 - repository context discovery and safe write policy (`#6`)

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1,0 +1,50 @@
+# gh-mcp-router v0.1 configuration.
+# This file contains identity references only; never add a PAT or token here.
+
+profiles:
+  personal:
+    provider: gh
+    user: mors119
+    host: github.com
+
+  work:
+    provider: gh
+    user: work-account
+    gh_config_dir: ~/.config/gh-work
+    host: github.com
+
+  enterprise:
+    provider: gh
+    user: enterprise-account
+    gh_config_dir: ${HOME}/.config/gh-enterprise
+    host: github.example.com
+
+# Rules are evaluated in order; the first matching rule wins.
+routes:
+  - match:
+      repo: ExampleOrg/security-*
+    profile: work
+
+  - match:
+      repo: ExampleOrg/platform
+    profile: work
+
+  - match:
+      owner: ExampleOrg
+    profile: work
+
+  - match:
+      host: github.example.com
+    profile: enterprise
+
+  - match:
+      owner: mors119
+    profile: personal
+
+default_profile: personal
+
+# Reads may use default_profile when no route matches; writes always fail
+# closed unless a route selects a profile.
+ambiguity_policy:
+  read: default_profile
+  write: error

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,117 @@
 //! Command-line presentation and dispatch.
-//!
-//! Command implementations are intentionally deferred to the CLI feature
-//! work. The binary currently provides only a small status message.
 
-/// Run the current placeholder command-line entry point.
+use std::{env, path::PathBuf};
+
+use crate::config::{Config, ConfigError};
+
+/// Run the command-line entry point, preserving the original library API.
 pub fn run() {
-    println!("gh-mcp-router: command-line interface not implemented yet");
+    if let Err(error) = try_run(env::args().skip(1)) {
+        eprintln!("gh-mcp-router: {error}");
+    }
+}
+
+/// Parse CLI arguments and validate configuration before a service command.
+///
+/// `--config PATH` may appear before or after the command. The `validate`
+/// command is useful for CI and `serve` deliberately loads configuration
+/// before its future MCP startup path.
+pub fn try_run<I, S>(args: I) -> Result<(), CliError>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut command = None;
+    let mut config_path = None;
+    let mut arguments = args.into_iter().map(Into::into).peekable();
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--config" => {
+                config_path = Some(PathBuf::from(
+                    arguments.next().ok_or(CliError::MissingConfigPath)?,
+                ));
+            }
+            value if value.starts_with("--config=") => {
+                let path = value.trim_start_matches("--config=");
+                if path.is_empty() {
+                    return Err(CliError::MissingConfigPath);
+                }
+                config_path = Some(PathBuf::from(path));
+            }
+            value if value.starts_with('-') => {
+                return Err(CliError::UnknownArgument(value.to_owned()))
+            }
+            value if command.is_none() => command = Some(value.to_owned()),
+            value => return Err(CliError::UnknownArgument(value.to_owned())),
+        }
+    }
+
+    match command.as_deref().unwrap_or("status") {
+        "validate" | "serve" => {
+            let config = match config_path {
+                Some(path) => Config::load(path)?,
+                None => Config::load_default()?,
+            };
+            if command.as_deref() == Some("validate") {
+                println!(
+                    "configuration is valid ({} profile(s), {} route(s))",
+                    config.profiles.len(),
+                    config.routes.len()
+                );
+            } else {
+                println!("configuration is valid; MCP server startup is not implemented yet");
+            }
+            Ok(())
+        }
+        "status" => {
+            if config_path.is_some() {
+                return Err(CliError::CommandNeedsConfig("status"));
+            }
+            println!("gh-mcp-router: command-line interface not implemented yet");
+            Ok(())
+        }
+        value => Err(CliError::UnknownCommand(value.to_owned())),
+    }
+}
+
+#[derive(Debug)]
+pub enum CliError {
+    MissingConfigPath,
+    UnknownArgument(String),
+    UnknownCommand(String),
+    CommandNeedsConfig(&'static str),
+    Config(ConfigError),
+}
+
+impl From<ConfigError> for CliError {
+    fn from(error: ConfigError) -> Self {
+        Self::Config(error)
+    }
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingConfigPath => formatter.write_str("--config requires a path"),
+            Self::UnknownArgument(argument) => write!(formatter, "unknown argument '{argument}'"),
+            Self::UnknownCommand(command) => write!(formatter, "unknown command '{command}'"),
+            Self::CommandNeedsConfig(command) => {
+                write!(formatter, "--config is not used by '{command}'")
+            }
+            Self::Config(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+#[cfg(test)]
+mod tests {
+    use super::try_run;
+
+    #[test]
+    fn invalid_explicit_config_fails_before_serve() {
+        let result = try_run(["serve", "--config", "/definitely/missing/config.yaml"]);
+        assert!(result.is_err());
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,24 +1,29 @@
-//! Configuration models.
+//! Serializable profile and routing configuration.
 //!
-//! This module owns the shape of profiles and route rules. Configuration file
-//! parsing and validation are deliberately deferred to a later feature.
+//! Configuration is a data-only boundary: it contains credential references,
+//! never credential values, and is validated before services are started.
+
+use std::{
+    collections::BTreeMap,
+    env, fmt, fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{
+    de::{MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use crate::credentials::CredentialRef;
 
-/// A named GitHub identity configuration.
-///
-/// A profile stores a reference to a credential provider. It never stores a
-/// plaintext credential value.
+/// A named GitHub identity configuration used by domain callers.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Profile {
-    /// Stable name used by route rules and routing decisions.
     pub name: String,
-    /// Provider-scoped reference used to obtain credentials later.
     pub credential: CredentialRef,
 }
 
 impl Profile {
-    /// Construct a profile from a name and a provider reference.
     pub fn new(name: impl Into<String>, credential: CredentialRef) -> Self {
         Self {
             name: name.into(),
@@ -27,57 +32,708 @@ impl Profile {
     }
 }
 
-/// A declarative route target and its optional repository match fields.
-///
-/// Matching and precedence are intentionally not implemented here. The
-/// fields establish the configuration boundary that the routing engine will
-/// consume later.
+/// A profile as represented in the configuration file.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileConfig {
+    /// Credential provider identifier, for example `gh`.
+    pub provider: String,
+    /// Provider account or username reference.
+    pub user: String,
+    /// Optional isolated GitHub CLI configuration directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gh_config_dir: Option<String>,
+    /// GitHub host, defaulting to `github.com`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+}
+
+impl ProfileConfig {
+    pub fn credential_ref(&self) -> CredentialRef {
+        CredentialRef::new(self.provider.clone(), self.user.clone())
+    }
+
+    pub fn expanded_gh_config_dir(&self) -> Result<Option<PathBuf>, ConfigError> {
+        self.gh_config_dir.as_deref().map(expand_path).transpose()
+    }
+}
+
+/// A route match. At least one field must be set.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RouteMatch {
+    /// Exact `owner/repo` or a repository glob containing one `*`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Exact GitHub owner or organization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// GitHub host, such as `github.com` or an Enterprise hostname.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+}
+
+/// An ordered route rule. The first matching rule wins.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RouteRule {
-    /// Profile name selected when this rule matches.
     pub profile: String,
-    /// Optional GitHub host constraint.
     pub host: Option<String>,
-    /// Optional owner or organization constraint.
     pub owner: Option<String>,
-    /// Optional repository or repository-pattern constraint.
     pub repository: Option<String>,
 }
 
 impl RouteRule {
-    /// Construct a route rule that targets a profile.
     pub fn for_profile(profile: impl Into<String>) -> Self {
         Self {
             profile: profile.into(),
             ..Self::default()
         }
     }
+
+    pub fn route_match(&self) -> RouteMatch {
+        RouteMatch {
+            repo: self.repository.clone(),
+            owner: self.owner.clone(),
+            host: self.host.clone(),
+        }
+    }
 }
+
+impl Serialize for RouteRule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct FileRule<'a> {
+            #[serde(rename = "match")]
+            route_match: RouteMatch,
+            profile: &'a str,
+        }
+        FileRule {
+            route_match: self.route_match(),
+            profile: &self.profile,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RouteRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct FileRule {
+            #[serde(rename = "match")]
+            route_match: RouteMatch,
+            profile: String,
+        }
+        let value = FileRule::deserialize(deserializer)?;
+        Ok(Self {
+            profile: value.profile,
+            host: value.route_match.host,
+            owner: value.route_match.owner,
+            repository: value.route_match.repo,
+        })
+    }
+}
+
+/// Policy used when no route gives an unambiguous profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AmbiguityPolicy {
+    Error,
+    DefaultProfile,
+}
+
+/// Explicit read/write ambiguity behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AmbiguityPolicyConfig {
+    #[serde(default = "default_read_policy")]
+    pub read: AmbiguityPolicy,
+    #[serde(default = "default_write_policy")]
+    pub write: AmbiguityPolicy,
+}
+
+impl Default for AmbiguityPolicyConfig {
+    fn default() -> Self {
+        Self {
+            read: default_read_policy(),
+            write: default_write_policy(),
+        }
+    }
+}
+
+fn default_read_policy() -> AmbiguityPolicy {
+    AmbiguityPolicy::DefaultProfile
+}
+fn default_write_policy() -> AmbiguityPolicy {
+    AmbiguityPolicy::Error
+}
+
+/// Complete v0.1 configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(deserialize_with = "deserialize_unique_profiles")]
+    pub profiles: BTreeMap<String, ProfileConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<RouteRule>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "is_default_policy")]
+    pub ambiguity_policy: AmbiguityPolicyConfig,
+}
+
+fn deserialize_unique_profiles<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<String, ProfileConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ProfilesVisitor;
+
+    impl<'de> Visitor<'de> for ProfilesVisitor {
+        type Value = BTreeMap<String, ProfileConfig>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map of unique profile names")
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut profiles = BTreeMap::new();
+            while let Some((name, profile)) = map.next_entry::<String, ProfileConfig>()? {
+                if profiles.insert(name.clone(), profile).is_some() {
+                    return Err(serde::de::Error::custom(format!(
+                        "duplicate profile '{name}'"
+                    )));
+                }
+            }
+            Ok(profiles)
+        }
+    }
+
+    deserializer.deserialize_map(ProfilesVisitor)
+}
+
+fn is_default_policy(policy: &AmbiguityPolicyConfig) -> bool {
+    *policy == AmbiguityPolicyConfig::default()
+}
+
+impl Config {
+    pub fn from_yaml_str(input: &str) -> Result<Self, ConfigError> {
+        let config: Self =
+            serde_yaml::from_str(input).map_err(|error| ConfigError::parse(error.to_string()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn from_json_str(input: &str) -> Result<Self, ConfigError> {
+        let config: Self =
+            serde_json::from_str(input).map_err(|error| ConfigError::parse(error.to_string()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(input: &str) -> Result<Self, ConfigError> {
+        Self::from_yaml_str(input)
+    }
+
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+        let path = path.as_ref();
+        let input =
+            fs::read_to_string(path).map_err(|error| ConfigError::io(path, error.to_string()))?;
+        if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+            Self::from_json_str(&input)
+        } else {
+            Self::from_yaml_str(&input)
+        }
+    }
+
+    pub fn load_default() -> Result<Self, ConfigError> {
+        Self::load(Self::default_path())
+    }
+
+    /// XDG on Unix, APPDATA on Windows, with a conventional HOME fallback.
+    pub fn default_path() -> PathBuf {
+        if cfg!(windows) {
+            if let Some(path) = env::var_os("APPDATA") {
+                return PathBuf::from(path).join("gh-mcp-router/config.yaml");
+            }
+            if let Some(home) = env::var_os("USERPROFILE") {
+                return PathBuf::from(home).join("AppData/Roaming/gh-mcp-router/config.yaml");
+            }
+        } else {
+            if let Some(path) = env::var_os("XDG_CONFIG_HOME") {
+                return PathBuf::from(path).join("gh-mcp-router/config.yaml");
+            }
+            if let Some(home) = env::var_os("HOME") {
+                return PathBuf::from(home).join(".config/gh-mcp-router/config.yaml");
+            }
+        }
+        if let Some(home) = env::var_os("HOME") {
+            return PathBuf::from(home).join(".config/gh-mcp-router/config.yaml");
+        }
+        PathBuf::from(".config/gh-mcp-router/config.yaml")
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.profiles.is_empty() {
+            return Err(ConfigError::validation(
+                "profiles",
+                "must contain at least one profile",
+            ));
+        }
+        for (name, profile) in &self.profiles {
+            validate_name(name, &format!("profiles.{name}"))?;
+            if profile.provider.trim().is_empty() {
+                return Err(ConfigError::validation(
+                    format!("profiles.{name}.provider"),
+                    "must not be empty",
+                ));
+            }
+            if profile.user.trim().is_empty() {
+                return Err(ConfigError::validation(
+                    format!("profiles.{name}.user"),
+                    "must not be empty",
+                ));
+            }
+            if let Some(host) = &profile.host {
+                validate_host(host, &format!("profiles.{name}.host"))?;
+            }
+            if profile.gh_config_dir.is_some() {
+                if let Err(error) = profile.expanded_gh_config_dir() {
+                    return Err(error.at_path(format!("profiles.{name}.gh_config_dir")));
+                }
+            }
+        }
+        if let Some(default) = &self.default_profile {
+            if !self.profiles.contains_key(default) {
+                return Err(ConfigError::validation(
+                    "default_profile",
+                    format!("references missing profile '{default}'"),
+                ));
+            }
+        }
+        for (index, route) in self.routes.iter().enumerate() {
+            let path = format!("routes[{index}]");
+            if !self.profiles.contains_key(&route.profile) {
+                return Err(ConfigError::validation(
+                    format!("{path}.profile"),
+                    format!("references missing profile '{}'", route.profile),
+                ));
+            }
+            if route.host.is_none() && route.owner.is_none() && route.repository.is_none() {
+                return Err(ConfigError::validation(
+                    format!("{path}.match"),
+                    "must contain repo, owner, or host",
+                ));
+            }
+            if let Some(host) = &route.host {
+                validate_host(host, &format!("{path}.match.host"))?;
+            }
+            if let Some(owner) = &route.owner {
+                validate_name(owner, &format!("{path}.match.owner"))?;
+            }
+            if let Some(repo) = &route.repository {
+                validate_repo_pattern(repo, &format!("{path}.match.repo"))?;
+                if let Some(owner) = &route.owner {
+                    let repo_owner = repo.split_once('/').map(|parts| parts.0);
+                    if repo_owner != Some(owner.as_str()) {
+                        return Err(ConfigError::validation(
+                            format!("{path}.match"),
+                            "owner conflicts with the owner in repo",
+                        ));
+                    }
+                }
+            }
+        }
+        self.validate_unreachable_routes()
+    }
+
+    fn validate_unreachable_routes(&self) -> Result<(), ConfigError> {
+        for later in 0..self.routes.len() {
+            for earlier in 0..later {
+                if route_subsumes(&self.routes[earlier], &self.routes[later]) {
+                    return Err(ConfigError::validation(format!("routes[{later}]"), format!("is unreachable because routes[{earlier}] matches every request it could match")));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_name(value: &str, path: &str) -> Result<(), ConfigError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value
+            .chars()
+            .any(|character| !(character.is_ascii_alphanumeric() || "-_".contains(character)))
+    {
+        return Err(ConfigError::validation(
+            path,
+            "must contain only ASCII letters, numbers, '-' or '_'",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_host(value: &str, path: &str) -> Result<(), ConfigError> {
+    if value.is_empty()
+        || value.contains('/')
+        || value.contains(':')
+        || value.chars().any(char::is_whitespace)
+        || value.starts_with('.')
+        || value.ends_with('.')
+    {
+        return Err(ConfigError::validation(
+            path,
+            "must be a hostname such as github.com",
+        ));
+    }
+    if value != "github.com" && value.parse::<std::net::IpAddr>().is_ok() {
+        return Err(ConfigError::validation(
+            path,
+            "must be a hostname, not an IP address",
+        ));
+    }
+    if value.split('.').any(|part| {
+        part.is_empty()
+            || part.starts_with('-')
+            || part.ends_with('-')
+            || part
+                .chars()
+                .any(|character| !(character.is_ascii_alphanumeric() || character == '-'))
+    }) {
+        return Err(ConfigError::validation(
+            path,
+            "contains an invalid hostname label",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_repo_pattern(value: &str, path: &str) -> Result<(), ConfigError> {
+    if value.matches('/').count() != 1
+        || value.contains("**")
+        || value.starts_with('/')
+        || value.ends_with('/')
+        || value.chars().any(char::is_whitespace)
+        || value.matches('*').count() > 1
+    {
+        return Err(ConfigError::validation(
+            path,
+            "must be owner/repo, with at most one '*' glob wildcard",
+        ));
+    }
+    if value.split('/').any(|part| {
+        part.is_empty()
+            || part
+                .chars()
+                .any(|character| !(character.is_ascii_alphanumeric() || "-_.*".contains(character)))
+    }) {
+        return Err(ConfigError::validation(
+            path,
+            "contains invalid owner or repository characters",
+        ));
+    }
+    Ok(())
+}
+
+fn route_subsumes(earlier: &RouteRule, later: &RouteRule) -> bool {
+    if !field_subsumes(&earlier.host, &later.host, false) {
+        return false;
+    }
+    if let Some(owner) = &earlier.owner {
+        let later_owner = later.owner.as_deref().or_else(|| {
+            later
+                .repository
+                .as_deref()
+                .and_then(|repo| repo.split_once('/').map(|parts| parts.0))
+        });
+        if later_owner != Some(owner.as_str()) {
+            return false;
+        }
+    }
+    match (&earlier.repository, &later.repository) {
+        (None, _) => true,
+        (Some(left), Some(right)) => glob_matches(left, right),
+        (Some(_), None) => false,
+    }
+}
+
+fn field_subsumes(earlier: &Option<String>, later: &Option<String>, glob: bool) -> bool {
+    match (earlier, later) {
+        (None, _) => true,
+        (Some(left), Some(right)) if left == right => true,
+        (Some(left), Some(right)) if glob => glob_matches(left, right),
+        _ => false,
+    }
+}
+
+fn glob_matches(pattern: &str, value: &str) -> bool {
+    match pattern.split_once('*') {
+        Some((prefix, suffix)) => {
+            value.starts_with(prefix)
+                && value.ends_with(suffix)
+                && value.len() >= prefix.len() + suffix.len()
+        }
+        None => pattern == value,
+    }
+}
+
+/// Expand only `~` and `$NAME`/`${NAME}` path references. Shell commands are
+/// never evaluated.
+pub fn expand_path(value: &str) -> Result<PathBuf, ConfigError> {
+    if value.contains("$(") || value.contains('`') {
+        return Err(ConfigError::validation(
+            "gh_config_dir",
+            "shell command expansion is not allowed",
+        ));
+    }
+    let mut input = value.to_owned();
+    if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
+        let home = env::var_os("HOME").ok_or_else(|| {
+            ConfigError::validation("gh_config_dir", "'~' requires HOME to be set")
+        })?;
+        input = if value == "~" {
+            home.to_string_lossy().into_owned()
+        } else {
+            PathBuf::from(home)
+                .join(&input[2..])
+                .to_string_lossy()
+                .into_owned()
+        };
+    } else if input.starts_with('~') {
+        return Err(ConfigError::validation(
+            "gh_config_dir",
+            "only '~' or '~/...' expansion is supported",
+        ));
+    }
+    let mut output = String::new();
+    let characters: Vec<char> = input.chars().collect();
+    let mut index = 0;
+    while index < characters.len() {
+        if characters[index] != '$' {
+            output.push(characters[index]);
+            index += 1;
+            continue;
+        }
+        let (name, next) = if characters.get(index + 1) == Some(&'{') {
+            let end = characters[index + 2..]
+                .iter()
+                .position(|character| *character == '}')
+                .ok_or_else(|| {
+                    ConfigError::validation("gh_config_dir", "unterminated '${...}' expansion")
+                })?
+                + index
+                + 2;
+            (
+                characters[index + 2..end].iter().collect::<String>(),
+                end + 1,
+            )
+        } else {
+            let end = (index + 1..characters.len())
+                .find(|position| {
+                    !(characters[*position].is_ascii_alphanumeric() || characters[*position] == '_')
+                })
+                .unwrap_or(characters.len());
+            (characters[index + 1..end].iter().collect::<String>(), end)
+        };
+        if name.is_empty()
+            || !name
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+            || name
+                .chars()
+                .any(|character| !(character.is_ascii_alphanumeric() || character == '_'))
+        {
+            return Err(ConfigError::validation(
+                "gh_config_dir",
+                "invalid environment variable expansion",
+            ));
+        }
+        let replacement = env::var_os(&name).ok_or_else(|| {
+            ConfigError::validation(
+                "gh_config_dir",
+                format!("environment variable '{name}' is not set"),
+            )
+        })?;
+        output.push_str(&replacement.to_string_lossy());
+        index = next;
+    }
+    if output.contains("$(") {
+        return Err(ConfigError::validation(
+            "gh_config_dir",
+            "shell command expansion is not allowed",
+        ));
+    }
+    Ok(PathBuf::from(output))
+}
+
+/// Actionable configuration failure with a field/path location.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    Io { path: PathBuf, message: String },
+    Parse { message: String },
+    Validation { path: String, message: String },
+}
+
+impl ConfigError {
+    fn io(path: &Path, message: String) -> Self {
+        Self::Io {
+            path: path.to_owned(),
+            message,
+        }
+    }
+    fn parse(message: String) -> Self {
+        Self::Parse { message }
+    }
+    fn validation(path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Validation {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+
+    fn at_path(self, path: impl Into<String>) -> Self {
+        match self {
+            Self::Validation { message, .. } => Self::Validation {
+                path: path.into(),
+                message,
+            },
+            other => other,
+        }
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, message } => write!(
+                formatter,
+                "cannot read config '{}': {message}",
+                path.display()
+            ),
+            Self::Parse { message } => write!(formatter, "invalid configuration syntax: {message}"),
+            Self::Validation { path, message } => {
+                write!(formatter, "invalid configuration at '{path}': {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{Profile, RouteRule};
-    use crate::credentials::CredentialRef;
+    use super::*;
+
+    fn minimal() -> &'static str {
+        "profiles:\n  personal:\n    provider: gh\n    user: mors119\n"
+    }
 
     #[test]
     fn profile_references_credentials_without_containing_a_token() {
         let profile = Profile::new("work", CredentialRef::new("gh", "work-account"));
-
         assert_eq!(profile.name, "work");
         assert_eq!(profile.credential.provider(), "gh");
-        assert_eq!(profile.credential.name(), "work-account");
     }
 
     #[test]
-    fn route_rule_can_be_constructed_independently() {
-        let rule = RouteRule {
-            profile: "work".to_owned(),
-            host: Some("github.com".to_owned()),
-            owner: Some("ExampleOrg".to_owned()),
-            repository: Some("backend".to_owned()),
-        };
+    fn valid_minimal_config_uses_safe_policy_defaults() {
+        let config = Config::from_yaml_str(minimal()).unwrap();
+        assert_eq!(
+            config.profiles["personal"].credential_ref().name(),
+            "mors119"
+        );
+        assert_eq!(
+            config.ambiguity_policy.read,
+            AmbiguityPolicy::DefaultProfile
+        );
+        assert_eq!(config.ambiguity_policy.write, AmbiguityPolicy::Error);
+    }
 
-        assert_eq!(rule.profile, "work");
-        assert_eq!(rule.owner.as_deref(), Some("ExampleOrg"));
+    #[test]
+    fn parses_profiles_and_ordered_routes() {
+        let input = "profiles:\n  personal:\n    provider: gh\n    user: mors119\n  work:\n    provider: gh\n    user: work-account\n    gh_config_dir: ~/.config/gh-work\nroutes:\n  - match:\n      repo: ExampleOrg/security-*\n    profile: work\n  - match:\n      owner: ExampleOrg\n    profile: work\ndefault_profile: personal\n";
+        let config = Config::from_yaml_str(input).unwrap();
+        assert_eq!(
+            config.routes[0].repository.as_deref(),
+            Some("ExampleOrg/security-*")
+        );
+        assert_eq!(config.default_profile.as_deref(), Some("personal"));
+    }
+
+    #[test]
+    fn rejects_duplicate_profiles() {
+        let error = Config::from_yaml_str(
+            "profiles:\n  work: { provider: gh, user: one }\n  work: { provider: gh, user: two }\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("profiles") || error.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn rejects_missing_profile_and_malformed_repo() {
+        let error = Config::from_yaml_str("profiles:\n  work: { provider: gh, user: work }\nroutes:\n  - match: { repo: not-a-repo }\n    profile: missing\n").unwrap_err();
+        assert!(error.to_string().contains("routes[0].profile"));
+    }
+
+    #[test]
+    fn rejects_secret_fields() {
+        let error = Config::from_yaml_str(
+            "profiles:\n  work: { provider: gh, user: work, token: plaintext }\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field") || error.to_string().contains("token"));
+    }
+
+    #[test]
+    fn catches_obviously_unreachable_ordered_rules() {
+        let error = Config::from_yaml_str("profiles:\n  work: { provider: gh, user: work }\nroutes:\n  - match: { owner: ExampleOrg }\n    profile: work\n  - match: { repo: ExampleOrg/security }\n    profile: work\n").unwrap_err();
+        assert!(error.to_string().contains("unreachable"));
+    }
+
+    #[test]
+    fn serialization_is_deterministic_and_uses_nested_match() {
+        let config = Config::from_yaml_str(minimal()).unwrap();
+        let first = serde_yaml::to_string(&config).unwrap();
+        let second = serde_yaml::to_string(&config).unwrap();
+        assert_eq!(first, second);
+        assert!(first.contains("profiles:"));
+    }
+
+    #[test]
+    fn expands_home_and_environment_paths_without_shell_evaluation() {
+        let home = env::var("HOME").unwrap();
+        let expanded = expand_path("~/gh-work/$HOME").unwrap();
+        assert_eq!(
+            expanded,
+            PathBuf::from(&home)
+                .join("gh-work")
+                .join(home.trim_start_matches('/'))
+        );
+        let error = expand_path("$(touch /tmp/should-not-run)").unwrap_err();
+        assert!(error.to_string().contains("shell command"));
+    }
+
+    #[test]
+    fn parses_json_and_reports_profile_path_for_expansion_errors() {
+        let config = Config::from_json_str(
+            r#"{"profiles":{"work":{"provider":"gh","user":"work"}},"routes":[]}"#,
+        )
+        .unwrap();
+        assert!(config.profiles.contains_key("work"));
+        let error = Config::from_yaml_str("profiles:\n  work:\n    provider: gh\n    user: work\n    gh_config_dir: ~other/.config/gh-work\n").unwrap_err();
+        assert!(error.to_string().contains("profiles.work.gh_config_dir"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
 fn main() {
-    gh_mcp_router::cli::run();
+    if let Err(error) = gh_mcp_router::cli::try_run(std::env::args().skip(1)) {
+        eprintln!("gh-mcp-router: {error}");
+        std::process::exit(2);
+    }
 }


### PR DESCRIPTION
## Summary
- Add serializable YAML/JSON profile and routing configuration models
- Validate duplicate profiles, route references, repository patterns, conflicts, and forbidden secret fields
- Support safe path expansion, platform default config paths, and config path overrides
- Add checked-in example configuration and the validate CLI command

## Verification
- cargo fmt --check
- cargo test (16 tests passed)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run --quiet -- validate --config examples/config.example.yaml

Closes #3