### PR TITLE
feat: add GitHub CLI credential provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "zeroize",
 ]
 
 [[package]]
@@ -147,6 +148,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+zeroize = "1"
 
 [lib]
 name = "gh_mcp_router"

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Instead, each profile should resolve its own credential without changing global 
 
 ### Local-first credential handling
 
-The initial credential provider will integrate with the GitHub CLI.
+The initial credential provider integrates with the GitHub CLI.
 
 Conceptually:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,10 @@ Official GitHub MCP Server
 GitHub
 ```
 
-The configuration boundary now parses and validates profiles and ordered route
-rules before later services start. Discovery, routing evaluation, credential
-providers, upstream sessions, and MCP forwarding remain separate concerns.
+The configuration boundary parses and validates profiles and ordered route rules
+before later services start. Credential providers resolve account references,
+while discovery, routing evaluation, upstream sessions, and MCP forwarding
+remain separate concerns.
 
 ## Module responsibilities
 
@@ -41,8 +42,8 @@ providers, upstream sessions, and MCP forwarding remain separate concerns.
 | `config` | Serializable profile/route models, parsing, path expansion, and validation | Credential retrieval or routing evaluation |
 | `context` | Normalized repository identity | Git remote or MCP root discovery |
 | `routing` | Pure routing decision domain | Credential retrieval, API calls, CLI state |
-| `credentials` | Credential references and provider interface | GitHub CLI discovery or token retrieval |
-| `security` | Secret-safe value formatting | Full lifecycle hardening and zeroization |
+| `credentials` | Credential references, GitHub CLI account discovery, and token retrieval | Repository/profile routing or GitHub API calls |
+| `security` | Secret-safe formatting and `SecretString` cleanup | Full lifecycle hardening beyond value cleanup |
 | `mcp` | Client-facing protocol/proxy boundary | Repository routing policy |
 | `upstream` | Official GitHub MCP session boundary | GitHub API/tool implementation |
 | `cli` | Presentation and command dispatch | The routing engine itself |
@@ -73,13 +74,15 @@ capabilities rather than duplicate their definitions.
 - Routing must not depend on global `gh auth switch` state.
 - There is no global mutable current-account state.
 - Credential retrieval and routing decisions remain separate concerns.
-- Ordinary `Debug` and `Display` formatting of secret values must redact them.
+- Ordinary `Debug` and `Display` formatting of secret values must redact them;
+  subprocess output is never included in provider errors.
 - Ambiguous write operations will eventually fail closed rather than guess an
   identity.
 
-These are design principles. This feature validates configuration and expands
-safe path references, but does not perform credential discovery, repository
-inference, routing evaluation, or MCP proxying.
+These are design principles. The GitHub CLI provider performs account discovery
+and on-demand token retrieval through explicit subprocess arguments and
+profile-specific `GH_CONFIG_DIR` values. Repository inference, routing
+evaluation, and MCP proxying remain separate concerns.
 
 ## Planned feature ownership
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,7 +50,14 @@ pub struct ProfileConfig {
 
 impl ProfileConfig {
     pub fn credential_ref(&self) -> CredentialRef {
-        CredentialRef::new(self.provider.clone(), self.user.clone())
+        let mut reference = CredentialRef::new(self.provider.clone(), self.user.clone());
+        if let Some(host) = &self.host {
+            reference = reference.with_host(host.clone());
+        }
+        if let Some(config_dir) = &self.gh_config_dir {
+            reference = reference.with_gh_config_dir(config_dir.clone());
+        }
+        reference
     }
 
     pub fn expanded_gh_config_dir(&self) -> Result<Option<PathBuf>, ConfigError> {
@@ -660,6 +667,21 @@ mod tests {
             AmbiguityPolicy::DefaultProfile
         );
         assert_eq!(config.ambiguity_policy.write, AmbiguityPolicy::Error);
+    }
+
+    #[test]
+    fn profile_credential_reference_preserves_non_secret_host_and_config_metadata() {
+        let config = Config::from_yaml_str(
+            "profiles:\n  work:\n    provider: gh\n    user: work-account\n    host: github.example.com\n    gh_config_dir: ~/.config/gh-work\n",
+        )
+        .unwrap();
+
+        let reference = config.profiles["work"].credential_ref();
+
+        assert_eq!(reference.provider(), "gh");
+        assert_eq!(reference.name(), "work-account");
+        assert_eq!(reference.host(), Some("github.example.com"));
+        assert_eq!(reference.gh_config_dir(), Some("~/.config/gh-work"));
     }
 
     #[test]

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -1,17 +1,37 @@
-//! Credential-provider abstractions.
+//! Credential-provider abstractions and the GitHub CLI implementation.
 //!
-//! This module identifies credentials without retrieving them. Provider
-//! implementations, including GitHub CLI integration, are deferred.
+//! This module owns credential lookup, but not profile or repository routing.
+//! The GitHub CLI is invoked with an explicit host, user, and optional
+//! `GH_CONFIG_DIR`; the process-global active account is never changed.
 
-use std::fmt;
+use std::{
+    collections::BTreeMap,
+    fmt,
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
 
+use serde::Deserialize;
+use zeroize::Zeroize;
+
+use crate::config::expand_path;
 use crate::security::SecretString;
+
+/// The host used when a credential reference does not specify one.
+pub const DEFAULT_GITHUB_HOST: &str = "github.com";
+
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A non-secret reference to a credential provider and account/profile name.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CredentialRef {
     provider: String,
     name: String,
+    host: Option<String>,
+    gh_config_dir: Option<String>,
 }
 
 impl CredentialRef {
@@ -20,7 +40,22 @@ impl CredentialRef {
         Self {
             provider: provider.into(),
             name: name.into(),
+            host: None,
+            gh_config_dir: None,
         }
+    }
+
+    /// Attach the GitHub host for this provider reference.
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+
+    /// Attach a profile-specific `GH_CONFIG_DIR` without expanding it yet.
+    /// Expansion is performed at the provider boundary, after validation.
+    pub fn with_gh_config_dir(mut self, path: impl Into<String>) -> Self {
+        self.gh_config_dir = Some(path.into());
+        self
     }
 
     /// Return the provider identifier.
@@ -32,6 +67,16 @@ impl CredentialRef {
     pub fn name(&self) -> &str {
         &self.name
     }
+
+    /// Return the configured host, if one was supplied.
+    pub fn host(&self) -> Option<&str> {
+        self.host.as_deref()
+    }
+
+    /// Return the configured, unexpanded `GH_CONFIG_DIR`, if one was supplied.
+    pub fn gh_config_dir(&self) -> Option<&str> {
+        self.gh_config_dir.as_deref()
+    }
 }
 
 /// Stable categories for provider failures.
@@ -41,6 +86,20 @@ pub enum CredentialErrorKind {
     Unavailable,
     /// The reference was not valid for the provider.
     InvalidReference,
+    /// The GitHub CLI executable could not be started.
+    GhNotInstalled,
+    /// The requested account is not authenticated for the host.
+    AuthenticationMissing,
+    /// The configured `GH_CONFIG_DIR` is not available.
+    ConfigDirMissing,
+    /// The requested host is not a valid GitHub host name.
+    UnsupportedHost,
+    /// The GitHub CLI returned data that could not be safely interpreted.
+    MalformedOutput,
+    /// The GitHub CLI did not finish within the configured timeout.
+    Timeout,
+    /// The GitHub CLI returned a failure status.
+    CommandFailed,
 }
 
 /// Typed provider error that contains no credential value.
@@ -72,6 +131,17 @@ impl fmt::Display for CredentialError {
         let description = match self.kind {
             CredentialErrorKind::Unavailable => "credential is unavailable",
             CredentialErrorKind::InvalidReference => "credential reference is invalid",
+            CredentialErrorKind::GhNotInstalled => "the 'gh' CLI is not installed",
+            CredentialErrorKind::AuthenticationMissing => "GitHub CLI authentication is missing",
+            CredentialErrorKind::ConfigDirMissing => {
+                "the configured GitHub CLI config directory is missing"
+            }
+            CredentialErrorKind::UnsupportedHost => "the GitHub host is unsupported",
+            CredentialErrorKind::MalformedOutput => {
+                "the GitHub CLI returned malformed authentication data"
+            }
+            CredentialErrorKind::Timeout => "the GitHub CLI command timed out",
+            CredentialErrorKind::CommandFailed => "the GitHub CLI command failed",
         };
 
         write!(
@@ -91,9 +161,507 @@ pub trait CredentialProvider {
     fn resolve(&self, reference: &CredentialRef) -> Result<SecretString, CredentialError>;
 }
 
+/// The source of a discovered authenticated account.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CredentialSource {
+    Gh,
+}
+
+impl fmt::Display for CredentialSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Gh => formatter.write_str("gh"),
+        }
+    }
+}
+
+/// Non-secret account information returned by `gh auth status`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GhAccount {
+    pub host: String,
+    pub user: String,
+    pub authenticated: bool,
+    pub source: CredentialSource,
+}
+
+/// A command request understood by the GitHub CLI runner.
+///
+/// Arguments are deliberately limited to command metadata. Credential values
+/// are returned by stdout and are never placed in this structure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommandRequest {
+    args: Vec<String>,
+    gh_config_dir: Option<PathBuf>,
+    timeout: Duration,
+}
+
+impl CommandRequest {
+    fn new<I, S>(args: I, gh_config_dir: Option<PathBuf>, timeout: Duration) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            args: args.into_iter().map(Into::into).collect(),
+            gh_config_dir,
+            timeout,
+        }
+    }
+
+    /// Return the command arguments for fake runners and diagnostics.
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    /// Return the profile-specific config directory, if present.
+    pub fn gh_config_dir(&self) -> Option<&Path> {
+        self.gh_config_dir.as_deref()
+    }
+
+    /// Return the command timeout.
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+}
+
+/// Output from a command runner. Its debug representation never contains
+/// stdout or stderr, and both buffers are zeroized when dropped.
+pub struct CommandOutput {
+    status: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl CommandOutput {
+    /// Construct successful output for a fake command runner.
+    pub fn success(stdout: impl Into<String>, stderr: impl Into<String>) -> Self {
+        Self {
+            status: Some(0),
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    /// Construct failed output for a fake command runner.
+    pub fn failure(status: i32, stdout: impl Into<String>, stderr: impl Into<String>) -> Self {
+        Self {
+            status: Some(status),
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    fn is_success(&self) -> bool {
+        self.status == Some(0)
+    }
+
+    fn into_stdout(mut self) -> String {
+        std::mem::take(&mut self.stdout)
+    }
+}
+
+impl fmt::Debug for CommandOutput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandOutput")
+            .field("status", &self.status)
+            .field("stdout", &"[REDACTED]")
+            .field("stderr", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Drop for CommandOutput {
+    fn drop(&mut self) {
+        self.stdout.zeroize();
+        self.stderr.zeroize();
+    }
+}
+
+/// Errors raised while starting or supervising a subprocess.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandRunnerError {
+    NotFound,
+    Io,
+    Timeout,
+}
+
+/// Injectable boundary for command execution. Tests use this instead of a
+/// contributor's real GitHub login.
+pub trait CommandRunner: Send + Sync {
+    fn run(&self, request: CommandRequest) -> Result<CommandOutput, CommandRunnerError>;
+}
+
+/// Real subprocess runner for the `gh` executable.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProcessCommandRunner;
+
+impl CommandRunner for ProcessCommandRunner {
+    fn run(&self, request: CommandRequest) -> Result<CommandOutput, CommandRunnerError> {
+        let mut command = Command::new("gh");
+        command.args(&request.args);
+        if let Some(config_dir) = &request.gh_config_dir {
+            command.env("GH_CONFIG_DIR", config_dir);
+        }
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let mut child = command.spawn().map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                CommandRunnerError::NotFound
+            } else {
+                CommandRunnerError::Io
+            }
+        })?;
+
+        let mut stdout = child.stdout.take().ok_or(CommandRunnerError::Io)?;
+        let mut stderr = child.stderr.take().ok_or(CommandRunnerError::Io)?;
+        let stdout_reader = thread::spawn(move || {
+            let mut output = String::new();
+            let result = stdout.read_to_string(&mut output);
+            (result, output)
+        });
+        let stderr_reader = thread::spawn(move || {
+            let mut output = String::new();
+            let result = stderr.read_to_string(&mut output);
+            (result, output)
+        });
+
+        let started = Instant::now();
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if started.elapsed() >= request.timeout => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(CommandRunnerError::Timeout);
+                }
+                Ok(None) => thread::sleep(Duration::from_millis(10)),
+                Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(CommandRunnerError::Io);
+                }
+            }
+        };
+
+        let (stdout_result, stdout) = stdout_reader.join().map_err(|_| CommandRunnerError::Io)?;
+        let (stderr_result, stderr) = stderr_reader.join().map_err(|_| CommandRunnerError::Io)?;
+        if stdout_result.is_err() || stderr_result.is_err() {
+            return Err(CommandRunnerError::Io);
+        }
+
+        Ok(CommandOutput {
+            status: status.code(),
+            stdout,
+            stderr,
+        })
+    }
+}
+
+/// GitHub CLI credential provider with injectable process execution.
+pub struct GhCliCredentialProvider<R = ProcessCommandRunner> {
+    runner: R,
+    timeout: Duration,
+}
+
+impl GhCliCredentialProvider<ProcessCommandRunner> {
+    /// Construct a provider that invokes the local `gh` executable.
+    pub fn new() -> Self {
+        Self {
+            runner: ProcessCommandRunner,
+            timeout: DEFAULT_COMMAND_TIMEOUT,
+        }
+    }
+}
+
+impl Default for GhCliCredentialProvider<ProcessCommandRunner> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R> GhCliCredentialProvider<R> {
+    /// Construct a provider using an injectable command runner.
+    pub fn with_runner(runner: R) -> Self {
+        Self {
+            runner,
+            timeout: DEFAULT_COMMAND_TIMEOUT,
+        }
+    }
+
+    /// Set the maximum duration of each `gh` subprocess.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+impl<R: CommandRunner> GhCliCredentialProvider<R> {
+    /// Verify that the `gh` executable can be started without exposing output.
+    pub fn verify_gh_installed(&self) -> Result<(), CredentialError> {
+        let reference = CredentialRef::new("gh", "cli");
+        match self
+            .runner
+            .run(CommandRequest::new(["--version"], None, self.timeout))
+        {
+            Ok(output) if output.is_success() => Ok(()),
+            Ok(_output) => Err(CredentialError::new(
+                reference,
+                CredentialErrorKind::CommandFailed,
+            )),
+            Err(CommandRunnerError::NotFound) => Err(CredentialError::new(
+                reference,
+                CredentialErrorKind::GhNotInstalled,
+            )),
+            Err(CommandRunnerError::Timeout) => Err(CredentialError::new(
+                reference,
+                CredentialErrorKind::Timeout,
+            )),
+            Err(CommandRunnerError::Io) => Err(CredentialError::new(
+                reference,
+                CredentialErrorKind::CommandFailed,
+            )),
+        }
+    }
+
+    /// Discover all accounts known to `gh` for a profile's host and config.
+    pub fn discover(&self, reference: &CredentialRef) -> Result<Vec<GhAccount>, CredentialError> {
+        self.validate_reference(reference)?;
+        let host = reference.host().unwrap_or(DEFAULT_GITHUB_HOST);
+        let config_dir = self.config_dir(reference)?;
+        let output = self.run(
+            reference,
+            CommandRequest::new(
+                ["auth", "status", "--hostname", host, "--json", "hosts"],
+                config_dir,
+                self.timeout,
+            ),
+        )?;
+        if !output.is_success() {
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::CommandFailed,
+            ));
+        }
+        let mut stdout = output.into_stdout();
+        let result = parse_accounts(&stdout, host, reference);
+        stdout.zeroize();
+        result
+    }
+
+    /// Verify that the exact configured account is authenticated without
+    /// retrieving its token.
+    pub fn verify_account(&self, reference: &CredentialRef) -> Result<GhAccount, CredentialError> {
+        let host = reference.host().unwrap_or(DEFAULT_GITHUB_HOST);
+        let account = self
+            .discover(reference)?
+            .into_iter()
+            .find(|account| account.host == host && account.user == reference.name());
+        match account {
+            Some(account) if account.authenticated => Ok(account),
+            _ => Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::AuthenticationMissing,
+            )),
+        }
+    }
+
+    /// Return the selected account's credential only after exact account
+    /// discovery succeeds.
+    pub fn resolve_reference(
+        &self,
+        reference: &CredentialRef,
+    ) -> Result<SecretString, CredentialError> {
+        self.verify_account(reference)?;
+        let host = reference.host().unwrap_or(DEFAULT_GITHUB_HOST);
+
+        let output = self.run(
+            reference,
+            CommandRequest::new(
+                [
+                    "auth",
+                    "token",
+                    "--hostname",
+                    host,
+                    "--user",
+                    reference.name(),
+                ],
+                self.config_dir(reference)?,
+                self.timeout,
+            ),
+        )?;
+        if !output.is_success() {
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::CommandFailed,
+            ));
+        }
+
+        let mut token_output = output.into_stdout();
+        let token = token_output.trim();
+        if token.is_empty() || token.chars().any(char::is_whitespace) {
+            token_output.zeroize();
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::MalformedOutput,
+            ));
+        }
+        let secret = SecretString::new(token);
+        token_output.zeroize();
+        Ok(secret)
+    }
+
+    fn validate_reference(&self, reference: &CredentialRef) -> Result<(), CredentialError> {
+        if reference.provider() != "gh" || reference.name().trim().is_empty() {
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::InvalidReference,
+            ));
+        }
+        let host = reference.host().unwrap_or(DEFAULT_GITHUB_HOST);
+        if !is_valid_host(host) {
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::UnsupportedHost,
+            ));
+        }
+        Ok(())
+    }
+
+    fn config_dir(&self, reference: &CredentialRef) -> Result<Option<PathBuf>, CredentialError> {
+        let Some(raw_path) = reference.gh_config_dir() else {
+            return Ok(None);
+        };
+        let path = expand_path(raw_path).map_err(|_| {
+            CredentialError::new(reference.clone(), CredentialErrorKind::InvalidReference)
+        })?;
+        if !path.is_dir() {
+            return Err(CredentialError::new(
+                reference.clone(),
+                CredentialErrorKind::ConfigDirMissing,
+            ));
+        }
+        Ok(Some(path))
+    }
+
+    fn run(
+        &self,
+        reference: &CredentialRef,
+        request: CommandRequest,
+    ) -> Result<CommandOutput, CredentialError> {
+        self.runner.run(request).map_err(|error| {
+            let kind = match error {
+                CommandRunnerError::NotFound => CredentialErrorKind::GhNotInstalled,
+                CommandRunnerError::Timeout => CredentialErrorKind::Timeout,
+                CommandRunnerError::Io => CredentialErrorKind::CommandFailed,
+            };
+            CredentialError::new(reference.clone(), kind)
+        })
+    }
+}
+
+impl<R: CommandRunner> CredentialProvider for GhCliCredentialProvider<R> {
+    fn resolve(&self, reference: &CredentialRef) -> Result<SecretString, CredentialError> {
+        self.resolve_reference(reference)
+    }
+}
+
+#[derive(Deserialize)]
+struct AuthStatus {
+    hosts: BTreeMap<String, Vec<AuthAccount>>,
+}
+
+#[derive(Deserialize)]
+struct AuthAccount {
+    #[serde(default)]
+    login: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    authenticated: Option<bool>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+fn parse_accounts(
+    stdout: &str,
+    requested_host: &str,
+    reference: &CredentialRef,
+) -> Result<Vec<GhAccount>, CredentialError> {
+    let parsed: AuthStatus = serde_json::from_str(stdout).map_err(|_| {
+        CredentialError::new(reference.clone(), CredentialErrorKind::MalformedOutput)
+    })?;
+    let entries = parsed.hosts.get(requested_host).ok_or_else(|| {
+        CredentialError::new(reference.clone(), CredentialErrorKind::MalformedOutput)
+    })?;
+    entries
+        .iter()
+        .map(|entry| {
+            let user = entry
+                .login
+                .as_deref()
+                .or(entry.user.as_deref())
+                .filter(|user| !user.trim().is_empty())
+                .ok_or_else(|| {
+                    CredentialError::new(reference.clone(), CredentialErrorKind::MalformedOutput)
+                })?;
+            let authenticated = entry
+                .authenticated
+                .or_else(|| {
+                    entry.state.as_deref().map(|state| {
+                        matches!(
+                            state.to_ascii_lowercase().as_str(),
+                            "success" | "authenticated"
+                        )
+                    })
+                })
+                .unwrap_or(true);
+            Ok(GhAccount {
+                host: requested_host.to_owned(),
+                user: user.to_owned(),
+                authenticated,
+                source: CredentialSource::Gh,
+            })
+        })
+        .collect()
+}
+
+fn is_valid_host(host: &str) -> bool {
+    !host.is_empty()
+        && host != "."
+        && !host.contains('/')
+        && !host.contains(':')
+        && !host.chars().any(char::is_whitespace)
+        && !host.starts_with('.')
+        && !host.ends_with('.')
+        && host.split('.').all(|part| {
+            !part.is_empty()
+                && !part.starts_with('-')
+                && !part.ends_with('-')
+                && part
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '-')
+        })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CredentialError, CredentialErrorKind, CredentialRef};
+    use std::{
+        collections::VecDeque,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use super::{
+        CommandOutput, CommandRequest, CommandRunner, CommandRunnerError, CredentialError,
+        CredentialErrorKind, CredentialProvider, CredentialRef, CredentialSource,
+        GhCliCredentialProvider,
+    };
 
     #[test]
     fn credential_reference_contains_identity_metadata_only() {
@@ -104,5 +672,238 @@ mod tests {
         assert_eq!(reference.name(), "work-account");
         assert_eq!(error.reference(), &reference);
         assert!(!error.to_string().contains("token"));
+    }
+
+    #[derive(Clone)]
+    struct FakeRunner {
+        responses: Arc<Mutex<VecDeque<Result<CommandOutput, CommandRunnerError>>>>,
+        requests: Arc<Mutex<Vec<CommandRequest>>>,
+        active_account: Arc<Mutex<String>>,
+    }
+
+    impl FakeRunner {
+        fn new(
+            responses: impl IntoIterator<Item = Result<CommandOutput, CommandRunnerError>>,
+        ) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+                requests: Arc::new(Mutex::new(Vec::new())),
+                active_account: Arc::new(Mutex::new("personal".to_owned())),
+            }
+        }
+
+        fn requests(&self) -> Vec<CommandRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+
+        fn active_account(&self) -> String {
+            self.active_account.lock().unwrap().clone()
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, request: CommandRequest) -> Result<CommandOutput, CommandRunnerError> {
+            self.requests.lock().unwrap().push(request);
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("fake command response")
+        }
+    }
+
+    fn status(accounts: &str) -> Result<CommandOutput, CommandRunnerError> {
+        status_for("github.com", accounts)
+    }
+
+    fn status_for(host: &str, accounts: &str) -> Result<CommandOutput, CommandRunnerError> {
+        Ok(CommandOutput::success(
+            format!(r#"{{"hosts":{{"{host}":[{accounts}]}}}}"#),
+            "",
+        ))
+    }
+
+    fn reference(user: &str) -> CredentialRef {
+        CredentialRef::new("gh", user).with_host("github.com")
+    }
+
+    #[test]
+    fn discovers_multiple_accounts_without_switching_the_active_account() {
+        let runner = FakeRunner::new([status(
+            r#"{"login":"personal","active":true,"state":"success"},{"login":"work","active":false,"state":"success"}"#,
+        )]);
+        let provider = GhCliCredentialProvider::with_runner(runner.clone());
+        let active_before = runner.active_account();
+
+        let accounts = provider.discover(&reference("personal")).unwrap();
+
+        assert_eq!(accounts.len(), 2);
+        assert_eq!(accounts[0].user, "personal");
+        assert_eq!(accounts[1].user, "work");
+        assert!(accounts.iter().all(|account| account.authenticated));
+        assert!(accounts
+            .iter()
+            .all(|account| account.source == CredentialSource::Gh));
+        let requests = runner.requests();
+        assert_eq!(requests[0].args()[..3], ["auth", "status", "--hostname"]);
+        assert!(!requests
+            .iter()
+            .any(|request| request.args().contains(&"switch".to_owned())));
+        assert_eq!(runner.active_account(), active_before);
+    }
+
+    #[test]
+    fn resolves_two_profiles_to_two_accounts_and_keeps_tokens_redacted() {
+        let runner = FakeRunner::new([
+            status(r#"{"login":"personal","state":"success"}"#),
+            Ok(CommandOutput::success("ghp_PERSONAL_FAKE\n", "")),
+            status(r#"{"login":"work","state":"success"}"#),
+            Ok(CommandOutput::success("github_pat_WORK_FAKE\n", "")),
+        ]);
+        let provider = GhCliCredentialProvider::with_runner(runner.clone());
+
+        let personal = provider.resolve(&reference("personal")).unwrap();
+        let work = provider.resolve(&reference("work")).unwrap();
+
+        assert_eq!(personal.expose(), "ghp_PERSONAL_FAKE");
+        assert_eq!(work.expose(), "github_pat_WORK_FAKE");
+        assert!(!format!("{personal:?}").contains("ghp_PERSONAL_FAKE"));
+        assert!(!work.to_string().contains("github_pat_WORK_FAKE"));
+        let requests = runner.requests();
+        assert_eq!(
+            requests[1].args().last().map(String::as_str),
+            Some("personal")
+        );
+        assert_eq!(requests[3].args().last().map(String::as_str), Some("work"));
+        assert!(!requests.iter().any(|request| {
+            request
+                .args()
+                .iter()
+                .any(|argument| argument.contains("ghp_") || argument.contains("github_pat_"))
+        }));
+    }
+
+    #[test]
+    fn honors_profile_specific_config_directories() {
+        let path = std::env::temp_dir();
+        let runner = FakeRunner::new([status(r#"{"login":"work","state":"success"}"#)]);
+        let reference = reference("work").with_gh_config_dir(path.to_string_lossy());
+        let provider = GhCliCredentialProvider::with_runner(runner.clone());
+
+        provider.discover(&reference).unwrap();
+
+        assert_eq!(runner.requests()[0].gh_config_dir(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn passes_custom_github_enterprise_hosts_without_special_case_routing() {
+        let runner = FakeRunner::new([status_for(
+            "github.example.com",
+            r#"{"login":"enterprise","state":"success"}"#,
+        )]);
+        let provider = GhCliCredentialProvider::with_runner(runner.clone());
+        let reference = CredentialRef::new("gh", "enterprise").with_host("github.example.com");
+
+        let accounts = provider.discover(&reference).unwrap();
+
+        assert_eq!(accounts[0].host, "github.example.com");
+        assert_eq!(runner.requests()[0].args()[3], "github.example.com");
+    }
+
+    #[test]
+    fn missing_account_is_reported_without_revealing_command_output() {
+        let runner = FakeRunner::new([status(r#"{"login":"other","state":"success"}"#)]);
+        let provider = GhCliCredentialProvider::with_runner(runner);
+
+        let error = provider.resolve(&reference("missing")).unwrap_err();
+
+        assert_eq!(error.kind(), CredentialErrorKind::AuthenticationMissing);
+        assert!(error.to_string().contains("missing"));
+        assert!(!format!("{error:?}").contains("ghp_"));
+    }
+
+    #[test]
+    fn expired_or_failed_authentication_is_not_usable() {
+        let runner = FakeRunner::new([status(r#"{"login":"work","state":"failure"}"#)]);
+        let provider = GhCliCredentialProvider::with_runner(runner);
+
+        let error = provider.verify_account(&reference("work")).unwrap_err();
+
+        assert_eq!(error.kind(), CredentialErrorKind::AuthenticationMissing);
+    }
+
+    #[test]
+    fn command_failures_and_subprocess_text_are_redacted() {
+        let runner = FakeRunner::new([
+            status(r#"{"login":"work","state":"success"}"#),
+            Ok(CommandOutput::failure(
+                1,
+                "github_pat_FAKE_TOKEN",
+                "Authorization: Bearer github_pat_FAKE_TOKEN",
+            )),
+        ]);
+        let provider = GhCliCredentialProvider::with_runner(runner);
+
+        let error = provider.resolve(&reference("work")).unwrap_err();
+
+        assert_eq!(error.kind(), CredentialErrorKind::CommandFailed);
+        assert!(!error.to_string().contains("github_pat_FAKE_TOKEN"));
+        assert!(!format!("{error:?}").contains("Authorization"));
+    }
+
+    #[test]
+    fn handles_missing_gh_timeout_bad_host_and_malformed_output() {
+        let not_installed = GhCliCredentialProvider::with_runner(FakeRunner::new([Err(
+            CommandRunnerError::NotFound,
+        )]));
+        assert_eq!(
+            not_installed.verify_gh_installed().unwrap_err().kind(),
+            CredentialErrorKind::GhNotInstalled
+        );
+
+        let timed_out = GhCliCredentialProvider::with_runner(FakeRunner::new([Err(
+            CommandRunnerError::Timeout,
+        )]));
+        assert_eq!(
+            timed_out.verify_gh_installed().unwrap_err().kind(),
+            CredentialErrorKind::Timeout
+        );
+
+        let bad_host = GhCliCredentialProvider::with_runner(FakeRunner::new([]));
+        let error = bad_host
+            .discover(&CredentialRef::new("gh", "user").with_host("https://github.com"))
+            .unwrap_err();
+        assert_eq!(error.kind(), CredentialErrorKind::UnsupportedHost);
+
+        let malformed = GhCliCredentialProvider::with_runner(FakeRunner::new([Ok(
+            CommandOutput::success("ghp_FAKE_TOKEN is not JSON", "Bearer ghp_FAKE_TOKEN"),
+        )]));
+        let error = malformed.discover(&reference("user")).unwrap_err();
+        assert_eq!(error.kind(), CredentialErrorKind::MalformedOutput);
+    }
+
+    #[test]
+    fn missing_config_directory_fails_before_running_gh() {
+        let runner = FakeRunner::new([]);
+        let provider = GhCliCredentialProvider::with_runner(runner.clone());
+        let reference = reference("work").with_gh_config_dir(
+            PathBuf::from("/definitely/missing/gh-config-dir").to_string_lossy(),
+        );
+
+        let error = provider.discover(&reference).unwrap_err();
+
+        assert_eq!(error.kind(), CredentialErrorKind::ConfigDirMissing);
+        assert!(runner.requests().is_empty());
+    }
+
+    #[test]
+    fn provider_timeout_configuration_is_passed_to_fake_runner() {
+        let runner = FakeRunner::new([status(r#"{"login":"user","state":"success"}"#)]);
+        let provider = GhCliCredentialProvider::with_runner(runner.clone())
+            .with_timeout(Duration::from_millis(5));
+
+        provider.discover(&reference("user")).unwrap();
+
+        assert_eq!(runner.requests()[0].timeout(), Duration::from_millis(5));
     }
 }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -2,10 +2,12 @@
 
 use std::fmt;
 
+use zeroize::Zeroize;
+
 /// A secret value whose ordinary formatting paths always redact its contents.
 ///
-/// Memory zeroization and provider-specific secret lifecycle rules are deferred
-/// until the security-hardening work has a concrete requirement.
+/// The backing string is zeroized when the value is dropped. Provider-specific
+/// secret lifecycle rules remain separate concerns.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SecretString(String);
 
@@ -30,6 +32,12 @@ impl fmt::Debug for SecretString {
 impl fmt::Display for SecretString {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("[REDACTED]")
+    }
+}
+
+impl Drop for SecretString {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
## Summary

- Add typed GitHub CLI account discovery and exact profile-account resolution.
- Retrieve credentials with explicit `--hostname` and `--user` arguments without global account switching.
- Preserve profile host/config metadata and redact/zeroize subprocess and secret values.

## Implementation

`GhCliCredentialProvider` uses an injectable `CommandRunner` for deterministic tests and a real process runner for `gh`. Discovery consumes `gh auth status --json hosts`; resolution verifies the exact authenticated account before calling `gh auth token`. Profile-specific `GH_CONFIG_DIR` values are expanded safely and passed as environment configuration, never as token-bearing arguments.

## Security / routing impact

Credential lookup remains separate from routing. The provider never invokes `gh auth switch`, never persists raw tokens, never includes subprocess stdout/stderr in errors, and never places tokens in command arguments. `SecretString` and command buffers redact ordinary formatting and zeroize on drop. Each request explicitly selects its configured host and user.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] Fake command-runner tests for two profiles/accounts and unchanged active-account state
- [x] Profile-specific `GH_CONFIG_DIR`, custom GitHub Enterprise host, missing/expired auth, missing `gh`, timeout, command failure, and malformed output coverage
- [x] Synthetic token checks for command arguments, errors, debug/display formatting, and subprocess output handling

## Out of scope

- Repository routing and precedence (#5)
- Repository context and write safety (#6)
- Upstream MCP session management (#7 and later)

Closes #4