### PR TITLE
feat: add deterministic repository profile routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ owner: ExampleOrg
 repo:  backend
 ```
 
-This normalized context can then be evaluated by the routing engine.
+This normalized context is evaluated by the pure routing engine. It returns the
+selected profile, the winning rule and specificity, or an explicit no-match or
+ambiguous result.
 
 ## Planned CLI
 
@@ -330,9 +332,14 @@ Use `--config PATH` to select another YAML or JSON file.
 The complete v0.1 schema is checked in at
 [`examples/config.example.yaml`](examples/config.example.yaml). It supports
 named credential references, optional per-profile `GH_CONFIG_DIR` and host
-isolation, ordered exact/glob repository, owner, and host routes, a default
-profile, and separate read/write ambiguity policies. Unknown fields are
-rejected, including token/PAT fields.
+isolation, exact/glob repository, owner, and host routes, a default profile,
+and separate read/write ambiguity policies. Routes are evaluated by
+`exact repository > repository glob > owner > host > default`; conflicting
+equally specific profiles produce an explicit ambiguous result. Unknown fields
+are rejected, including token/PAT fields. GitHub host, owner, and repository
+matching is case-insensitive; explanations retain the configured spelling. If
+equally specific matching rules select the same profile, the first configured
+rule is reported as the stable tie-breaker.
 
 The remaining commands are part of the v0.1 roadmap and are not available yet;
 `validate` is available now for checking configuration files.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,12 @@ Official GitHub MCP Server
 GitHub
 ```
 
-The configuration boundary now parses and validates profiles and ordered route
-rules before later services start. Discovery, routing evaluation, credential
-providers, upstream sessions, and MCP forwarding remain separate concerns.
+The configuration boundary parses and validates profiles and route rules before
+later services start. The routing boundary evaluates those rules by explicit
+specificity and returns explainable selected, no-match, or ambiguous results.
+Host, owner, and repository comparisons are case-insensitive while explanation
+metadata retains the configured spelling. Discovery, credential providers,
+upstream sessions, and MCP forwarding remain separate concerns.
 
 ## Module responsibilities
 
@@ -40,7 +43,7 @@ providers, upstream sessions, and MCP forwarding remain separate concerns.
 | --- | --- | --- |
 | `config` | Serializable profile/route models, parsing, path expansion, and validation | Credential retrieval or routing evaluation |
 | `context` | Normalized repository identity | Git remote or MCP root discovery |
-| `routing` | Pure routing decision domain | Credential retrieval, API calls, CLI state |
+| `routing` | Pure, deterministic repository-to-profile evaluation | Credential retrieval, API calls, CLI state |
 | `credentials` | Credential references and provider interface | GitHub CLI discovery or token retrieval |
 | `security` | Secret-safe value formatting | Full lifecycle hardening and zeroization |
 | `mcp` | Client-facing protocol/proxy boundary | Repository routing policy |
@@ -77,9 +80,9 @@ capabilities rather than duplicate their definitions.
 - Ambiguous write operations will eventually fail closed rather than guess an
   identity.
 
-These are design principles. This feature validates configuration and expands
-safe path references, but does not perform credential discovery, repository
-inference, routing evaluation, or MCP proxying.
+These are design principles. Routing evaluates only normalized repository
+context and profile references; it does not perform credential discovery,
+repository inference, or MCP proxying.
 
 ## Planned feature ownership
 
@@ -87,7 +90,7 @@ The next features add behavior behind the boundaries established here:
 
 - configuration parsing and validation (`#3`, implemented)
 - GitHub CLI credential discovery (`#4`)
-- deterministic routing evaluation (`#5`)
+- deterministic routing evaluation (`#5`, implemented)
 - repository context discovery and safe write policy (`#6`)
 - profile-isolated upstream sessions (`#7`)
 - MCP request forwarding (`#8`)

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -19,7 +19,8 @@ profiles:
     gh_config_dir: ${HOME}/.config/gh-enterprise
     host: github.example.com
 
-# Rules are evaluated in order; the first matching rule wins.
+# Rules are compared by specificity: exact repo > repo glob > owner > host.
+# If equally specific rules select different profiles, routing is ambiguous.
 routes:
   - match:
       repo: ExampleOrg/security-*

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -73,7 +73,8 @@ pub struct RouteMatch {
     pub host: Option<String>,
 }
 
-/// An ordered route rule. The first matching rule wins.
+/// A route rule. The routing engine compares matching rules by specificity;
+/// configuration order only makes same-profile ties stable.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RouteRule {
     pub profile: String,
@@ -346,23 +347,12 @@ impl Config {
                 validate_repo_pattern(repo, &format!("{path}.match.repo"))?;
                 if let Some(owner) = &route.owner {
                     let repo_owner = repo.split_once('/').map(|parts| parts.0);
-                    if repo_owner != Some(owner.as_str()) {
+                    if repo_owner.is_none_or(|repo_owner| !repo_owner.eq_ignore_ascii_case(owner)) {
                         return Err(ConfigError::validation(
                             format!("{path}.match"),
                             "owner conflicts with the owner in repo",
                         ));
                     }
-                }
-            }
-        }
-        self.validate_unreachable_routes()
-    }
-
-    fn validate_unreachable_routes(&self) -> Result<(), ConfigError> {
-        for later in 0..self.routes.len() {
-            for earlier in 0..later {
-                if route_subsumes(&self.routes[earlier], &self.routes[later]) {
-                    return Err(ConfigError::validation(format!("routes[{later}]"), format!("is unreachable because routes[{earlier}] matches every request it could match")));
                 }
             }
         }
@@ -445,48 +435,6 @@ fn validate_repo_pattern(value: &str, path: &str) -> Result<(), ConfigError> {
         ));
     }
     Ok(())
-}
-
-fn route_subsumes(earlier: &RouteRule, later: &RouteRule) -> bool {
-    if !field_subsumes(&earlier.host, &later.host, false) {
-        return false;
-    }
-    if let Some(owner) = &earlier.owner {
-        let later_owner = later.owner.as_deref().or_else(|| {
-            later
-                .repository
-                .as_deref()
-                .and_then(|repo| repo.split_once('/').map(|parts| parts.0))
-        });
-        if later_owner != Some(owner.as_str()) {
-            return false;
-        }
-    }
-    match (&earlier.repository, &later.repository) {
-        (None, _) => true,
-        (Some(left), Some(right)) => glob_matches(left, right),
-        (Some(_), None) => false,
-    }
-}
-
-fn field_subsumes(earlier: &Option<String>, later: &Option<String>, glob: bool) -> bool {
-    match (earlier, later) {
-        (None, _) => true,
-        (Some(left), Some(right)) if left == right => true,
-        (Some(left), Some(right)) if glob => glob_matches(left, right),
-        _ => false,
-    }
-}
-
-fn glob_matches(pattern: &str, value: &str) -> bool {
-    match pattern.split_once('*') {
-        Some((prefix, suffix)) => {
-            value.starts_with(prefix)
-                && value.ends_with(suffix)
-                && value.len() >= prefix.len() + suffix.len()
-        }
-        None => pattern == value,
-    }
 }
 
 /// Expand only `~` and `$NAME`/`${NAME}` path references. Shell commands are
@@ -698,9 +646,9 @@ mod tests {
     }
 
     #[test]
-    fn catches_obviously_unreachable_ordered_rules() {
-        let error = Config::from_yaml_str("profiles:\n  work: { provider: gh, user: work }\nroutes:\n  - match: { owner: ExampleOrg }\n    profile: work\n  - match: { repo: ExampleOrg/security }\n    profile: work\n").unwrap_err();
-        assert!(error.to_string().contains("unreachable"));
+    fn allows_broad_rules_before_narrow_rules_for_specificity_routing() {
+        let config = Config::from_yaml_str("profiles:\n  work: { provider: gh, user: work }\nroutes:\n  - match: { owner: ExampleOrg }\n    profile: work\n  - match: { repo: ExampleOrg/security }\n    profile: work\n").unwrap();
+        assert_eq!(config.routes.len(), 2);
     }
 
     #[test]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -16,7 +16,7 @@ pub enum ContextSource {
     ConfiguredFallback,
 }
 
-/// Repository identity used by future routing decisions.
+/// Repository identity consumed by routing decisions.
 ///
 /// This type contains no authentication state and can therefore be created and
 /// passed through the application independently of credential handling.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Architectural foundation for `gh-mcp-router`.
 //!
 //! The crate is intentionally small. These modules define ownership boundaries
-//! for later features without performing discovery, routing, or MCP work yet.
+//! while keeping repository routing separate from discovery, credentials, and
+//! MCP work.
 
 pub mod cli;
 pub mod config;

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,10 +1,18 @@
-//! Pure routing decision domain.
+//! Deterministic, side-effect-free repository-to-profile routing.
 //!
-//! This module will eventually evaluate repository context and configuration.
-//! It does not retrieve credentials, invoke external commands, call GitHub or
-//! MCP APIs, or own CLI presentation state.
+//! Routing consumes only normalized repository context and typed configuration.
+//! It does not retrieve credentials, execute subprocesses, call GitHub APIs,
+//! or know about MCP transport. A route selects a credential *profile*; a
+//! separate credential provider resolves that profile later.
 
-/// Broad operation policy used when a future router evaluates a request.
+use std::fmt;
+
+use crate::{
+    config::{Config, RouteRule},
+    context::RepositoryContext,
+};
+
+/// Broad operation policy used by later request-routing features.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OperationClass {
     /// An operation that does not change GitHub state.
@@ -13,38 +21,522 @@ pub enum OperationClass {
     Write,
 }
 
-/// The profile selected by a future routing evaluation.
+/// Specificity used to compare otherwise matching route rules.
 ///
-/// The decision carries a profile identifier only. Credential resolution is a
-/// separate concern and is never represented by a plaintext token here.
+/// The order is intentionally explicit and is part of the v0.1 routing
+/// contract: exact repository, repository glob, owner, host, then default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RouteSpecificity {
+    ExactRepository,
+    RepositoryGlob,
+    Owner,
+    Host,
+    Default,
+}
+
+impl fmt::Display for RouteSpecificity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::ExactRepository => "exact_repository",
+            Self::RepositoryGlob => "repository_glob",
+            Self::Owner => "owner",
+            Self::Host => "host",
+            Self::Default => "default",
+        };
+        formatter.write_str(value)
+    }
+}
+
+/// Explainable metadata for a selected route.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RoutingDecision {
-    pub profile: String,
-    pub operation: OperationClass,
+    /// The repository identity rendered as `owner/repository` from context.
+    pub repository: String,
+    /// The profile name to pass to the credential/session layers.
+    pub selected_profile: String,
+    /// A human-readable description of the winning rule, or `None` for the
+    /// configured default profile.
     pub matched_rule: Option<String>,
+    pub specificity: RouteSpecificity,
+    pub fallback_used: bool,
 }
 
 impl RoutingDecision {
-    /// Construct a decision without performing route evaluation.
-    pub fn new(profile: impl Into<String>, operation: OperationClass) -> Self {
-        Self {
-            profile: profile.into(),
-            operation,
-            matched_rule: None,
+    /// Return the selected profile without exposing or resolving credentials.
+    pub fn profile(&self) -> &str {
+        &self.selected_profile
+    }
+}
+
+/// A route candidate involved in an ambiguous result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteCandidate {
+    pub profile: String,
+    pub matched_rule: String,
+}
+
+/// Returned when equally specific rules select different profiles.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AmbiguousRouting {
+    pub repository: String,
+    pub specificity: RouteSpecificity,
+    pub candidates: Vec<RouteCandidate>,
+}
+
+/// Returned when no route and no default profile apply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NoMatch {
+    pub repository: String,
+}
+
+/// Complete result of a routing evaluation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RoutingResult {
+    Selected(RoutingDecision),
+    NoMatch(NoMatch),
+    Ambiguous(AmbiguousRouting),
+}
+
+impl RoutingResult {
+    pub fn selected_profile(&self) -> Option<&str> {
+        match self {
+            Self::Selected(decision) => Some(decision.profile()),
+            Self::NoMatch(_) | Self::Ambiguous(_) => None,
         }
+    }
+}
+
+/// Pure evaluator for a validated configuration.
+pub struct RoutingEngine<'config> {
+    config: &'config Config,
+}
+
+impl<'config> RoutingEngine<'config> {
+    pub fn new(config: &'config Config) -> Self {
+        Self { config }
+    }
+
+    /// Evaluate all matching rules and select the highest-specificity level.
+    ///
+    /// Multiple rules at that level are safe to resolve only when they select
+    /// the same profile. Conflicting profiles return `Ambiguous`, even when
+    /// one appeared earlier in the configuration, so a write cannot silently
+    /// use an unintended identity.
+    pub fn evaluate(&self, context: &RepositoryContext) -> RoutingResult {
+        evaluate(self.config, context)
+    }
+
+    pub fn route(&self, context: &RepositoryContext) -> RoutingResult {
+        self.evaluate(context)
+    }
+}
+
+/// Evaluate a repository context against a configuration.
+pub fn evaluate(config: &Config, context: &RepositoryContext) -> RoutingResult {
+    let repository = repository_name(context);
+    let mut best_specificity = None;
+    let mut matches = Vec::new();
+
+    for rule in &config.routes {
+        let Some(specificity) = matching_specificity(rule, context) else {
+            continue;
+        };
+
+        match best_specificity {
+            None => {
+                best_specificity = Some(specificity);
+                matches.push((rule, specificity));
+            }
+            Some(best) if specificity_rank(specificity) < specificity_rank(best) => {}
+            Some(best) if specificity_rank(specificity) > specificity_rank(best) => {
+                best_specificity = Some(specificity);
+                matches.clear();
+                matches.push((rule, specificity));
+            }
+            Some(_) => matches.push((rule, specificity)),
+        }
+    }
+
+    if let Some(specificity) = best_specificity {
+        let candidates = matches
+            .iter()
+            .map(|(rule, _)| RouteCandidate {
+                profile: rule.profile.clone(),
+                matched_rule: describe_rule(rule),
+            })
+            .collect::<Vec<_>>();
+        let first = &candidates[0];
+
+        if candidates
+            .iter()
+            .any(|candidate| candidate.profile != first.profile)
+        {
+            return RoutingResult::Ambiguous(AmbiguousRouting {
+                repository,
+                specificity,
+                candidates,
+            });
+        }
+
+        return RoutingResult::Selected(RoutingDecision {
+            repository,
+            selected_profile: first.profile.clone(),
+            matched_rule: Some(first.matched_rule.clone()),
+            specificity,
+            fallback_used: false,
+        });
+    }
+
+    match &config.default_profile {
+        Some(profile) => RoutingResult::Selected(RoutingDecision {
+            repository,
+            selected_profile: profile.clone(),
+            matched_rule: None,
+            specificity: RouteSpecificity::Default,
+            fallback_used: true,
+        }),
+        None => RoutingResult::NoMatch(NoMatch { repository }),
+    }
+}
+
+/// Alias emphasizing that this function performs no external work.
+pub fn route(config: &Config, context: &RepositoryContext) -> RoutingResult {
+    evaluate(config, context)
+}
+
+fn repository_name(context: &RepositoryContext) -> String {
+    format!("{}/{}", context.owner.trim(), context.repository.trim())
+}
+
+fn normalized_repository_name(context: &RepositoryContext) -> String {
+    normalize(&repository_name(context))
+}
+
+fn matching_specificity(rule: &RouteRule, context: &RepositoryContext) -> Option<RouteSpecificity> {
+    if rule
+        .host
+        .as_deref()
+        .is_some_and(|host| normalize(host) != normalize(&context.host))
+    {
+        return None;
+    }
+    if rule
+        .owner
+        .as_deref()
+        .is_some_and(|owner| normalize(owner) != normalize(&context.owner))
+    {
+        return None;
+    }
+
+    if let Some(pattern) = &rule.repository {
+        let repository = normalized_repository_name(context);
+        let pattern = normalize(pattern);
+        if pattern.contains('*') {
+            glob_matches(&pattern, &repository).then_some(RouteSpecificity::RepositoryGlob)
+        } else {
+            (pattern == repository).then_some(RouteSpecificity::ExactRepository)
+        }
+    } else if rule.owner.is_some() {
+        Some(RouteSpecificity::Owner)
+    } else if rule.host.is_some() {
+        Some(RouteSpecificity::Host)
+    } else {
+        None
+    }
+}
+
+fn describe_rule(rule: &RouteRule) -> String {
+    let mut fields = Vec::new();
+    if let Some(repository) = &rule.repository {
+        fields.push(format!("repo: {}", repository.trim()));
+    }
+    if let Some(owner) = &rule.owner {
+        fields.push(format!("owner: {}", owner.trim()));
+    }
+    if let Some(host) = &rule.host {
+        fields.push(format!("host: {}", host.trim()));
+    }
+    fields.join(", ")
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn specificity_rank(specificity: RouteSpecificity) -> u8 {
+    match specificity {
+        RouteSpecificity::ExactRepository => 5,
+        RouteSpecificity::RepositoryGlob => 4,
+        RouteSpecificity::Owner => 3,
+        RouteSpecificity::Host => 2,
+        RouteSpecificity::Default => 1,
+    }
+}
+
+/// Match one `*` without allowing it to cross the repository-name separator.
+fn glob_matches(pattern: &str, value: &str) -> bool {
+    let Some((pattern_owner, pattern_repository)) = pattern.split_once('/') else {
+        return false;
+    };
+    let Some((owner, repository)) = value.split_once('/') else {
+        return false;
+    };
+    segment_glob_matches(pattern_owner, owner)
+        && segment_glob_matches(pattern_repository, repository)
+}
+
+fn segment_glob_matches(pattern: &str, value: &str) -> bool {
+    if value.contains('/') {
+        return false;
+    }
+    match pattern.split_once('*') {
+        Some((prefix, suffix)) => {
+            value.starts_with(prefix)
+                && value.ends_with(suffix)
+                && value.len() >= prefix.len() + suffix.len()
+        }
+        None => pattern == value,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OperationClass, RoutingDecision};
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::{
+        config::{ProfileConfig, RouteRule},
+        context::ContextSource,
+    };
+
+    fn config(routes: Vec<RouteRule>, default_profile: Option<&str>) -> Config {
+        let profiles = ["personal", "work", "other"]
+            .into_iter()
+            .map(|name| {
+                (
+                    name.to_owned(),
+                    ProfileConfig {
+                        provider: "gh".to_owned(),
+                        user: name.to_owned(),
+                        gh_config_dir: None,
+                        host: None,
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        Config {
+            profiles,
+            routes,
+            default_profile: default_profile.map(str::to_owned),
+            ambiguity_policy: Default::default(),
+        }
+    }
+
+    fn rule(
+        profile: &str,
+        repository: Option<&str>,
+        owner: Option<&str>,
+        host: Option<&str>,
+    ) -> RouteRule {
+        RouteRule {
+            profile: profile.to_owned(),
+            repository: repository.map(str::to_owned),
+            owner: owner.map(str::to_owned),
+            host: host.map(str::to_owned),
+        }
+    }
+
+    fn context(host: &str, owner: &str, repository: &str) -> RepositoryContext {
+        RepositoryContext::new(host, owner, repository, ContextSource::Explicit)
+    }
+
+    fn selected(result: RoutingResult) -> RoutingDecision {
+        match result {
+            RoutingResult::Selected(decision) => decision,
+            other => panic!("expected selected result, got {other:?}"),
+        }
+    }
 
     #[test]
-    fn routing_decision_is_independent_of_credential_values() {
-        let decision = RoutingDecision::new("work", OperationClass::Write);
+    fn exact_repository_overrides_owner() {
+        let config = config(
+            vec![
+                rule("personal", None, Some("ExampleOrg"), None),
+                rule("work", Some("ExampleOrg/private-api"), None, None),
+            ],
+            None,
+        );
+        let decision = selected(evaluate(
+            &config,
+            &context("github.com", "ExampleOrg", "private-api"),
+        ));
 
-        assert_eq!(decision.profile, "work");
-        assert_eq!(decision.operation, OperationClass::Write);
+        assert_eq!(decision.selected_profile, "work");
+        assert_eq!(decision.specificity, RouteSpecificity::ExactRepository);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("repo: ExampleOrg/private-api")
+        );
+        assert!(!decision.fallback_used);
+    }
+
+    #[test]
+    fn repository_glob_overrides_owner_and_does_not_cross_separator() {
+        let config = config(
+            vec![
+                rule("personal", None, Some("ExampleOrg"), None),
+                rule("work", Some("ExampleOrg/security-*"), None, None),
+            ],
+            None,
+        );
+        let decision = selected(evaluate(
+            &config,
+            &context("github.com", "exampleorg", "security-api"),
+        ));
+
+        assert_eq!(decision.selected_profile, "work");
+        assert_eq!(decision.specificity, RouteSpecificity::RepositoryGlob);
+        assert!(!glob_matches(
+            "exampleorg/security-*",
+            "exampleorg/security-api/x"
+        ));
+    }
+
+    #[test]
+    fn owner_overrides_host() {
+        let config = config(
+            vec![
+                rule("personal", None, None, Some("github.com")),
+                rule("work", None, Some("ExampleOrg"), None),
+            ],
+            None,
+        );
+        let decision = selected(evaluate(
+            &config,
+            &context("github.com", "EXAMPLEORG", "backend"),
+        ));
+
+        assert_eq!(decision.selected_profile, "work");
+        assert_eq!(decision.specificity, RouteSpecificity::Owner);
+    }
+
+    #[test]
+    fn host_routes_are_separated_by_normalized_host() {
+        let config = config(
+            vec![
+                rule("personal", None, None, Some("github.com")),
+                rule("work", None, None, Some("github.example.com")),
+            ],
+            None,
+        );
+        let github = selected(evaluate(
+            &config,
+            &context("GITHUB.COM", "ExampleOrg", "repo"),
+        ));
+        let enterprise = selected(evaluate(
+            &config,
+            &context("github.example.com", "ExampleOrg", "repo"),
+        ));
+        assert_eq!(github.selected_profile, "personal");
+        assert_eq!(enterprise.selected_profile, "work");
+
+        let result = evaluate(&config, &context("other.example.com", "ExampleOrg", "repo"));
+        assert!(matches!(result, RoutingResult::NoMatch(_)));
+    }
+
+    #[test]
+    fn default_is_used_only_when_nothing_matches() {
+        let config = config(
+            vec![rule("work", None, Some("ExampleOrg"), None)],
+            Some("personal"),
+        );
+        let decision = selected(evaluate(
+            &config,
+            &context("github.com", "OtherOrg", "repo"),
+        ));
+
+        assert_eq!(decision.selected_profile, "personal");
+        assert_eq!(decision.specificity, RouteSpecificity::Default);
         assert!(decision.matched_rule.is_none());
+        assert!(decision.fallback_used);
+    }
+
+    #[test]
+    fn no_default_returns_no_match() {
+        let result = evaluate(
+            &config(Vec::new(), None),
+            &context("github.com", "ExampleOrg", "repo"),
+        );
+        assert_eq!(
+            result,
+            RoutingResult::NoMatch(NoMatch {
+                repository: "ExampleOrg/repo".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn conflicting_equally_specific_routes_are_ambiguous() {
+        let config = config(
+            vec![
+                rule("personal", Some("ExampleOrg/repo"), None, None),
+                rule("work", Some("exampleorg/REPO"), None, None),
+            ],
+            Some("other"),
+        );
+        let result = evaluate(&config, &context("github.com", "exampleorg", "repo"));
+
+        match result {
+            RoutingResult::Ambiguous(ambiguous) => {
+                assert_eq!(ambiguous.specificity, RouteSpecificity::ExactRepository);
+                assert_eq!(ambiguous.candidates.len(), 2);
+                assert_eq!(ambiguous.candidates[0].profile, "personal");
+                assert_eq!(ambiguous.candidates[1].profile, "work");
+            }
+            other => panic!("expected ambiguous result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn same_specificity_same_profile_is_deterministic() {
+        let config = config(
+            vec![
+                rule("work", None, Some("ExampleOrg"), None),
+                rule("work", None, Some("exampleorg"), None),
+            ],
+            None,
+        );
+        let decision = selected(evaluate(
+            &config,
+            &context("github.com", "ExampleOrg", "repo"),
+        ));
+        assert_eq!(decision.selected_profile, "work");
+        assert_eq!(decision.matched_rule.as_deref(), Some("owner: ExampleOrg"));
+    }
+
+    #[test]
+    fn unrelated_configuration_does_not_change_explanation() {
+        let base = config(vec![rule("work", None, Some("ExampleOrg"), None)], None);
+        let extended = config(
+            vec![
+                rule("other", None, Some("Unrelated"), None),
+                rule("work", None, Some("ExampleOrg"), None),
+            ],
+            None,
+        );
+        let context = context("github.com", "ExampleOrg", "repo");
+        assert_eq!(evaluate(&base, &context), evaluate(&extended, &context));
+    }
+
+    #[test]
+    fn routing_types_contain_no_credential_values() {
+        let config = config(
+            vec![rule("work", Some("ExampleOrg/repo"), None, None)],
+            None,
+        );
+        let result = evaluate(&config, &context("github.com", "ExampleOrg", "repo"));
+        let formatted = format!("{result:?}");
+        assert!(!formatted.contains("ghp_"));
+        assert!(!formatted.contains("github_pat_"));
     }
 }


### PR DESCRIPTION
## Summary

- Add pure repository-to-profile routing evaluation.
- Implement exact, glob, owner, host, and default precedence.
- Return explainable selected, no-match, and ambiguous results.

## Implementation

The routing engine consumes only `Config` and `RepositoryContext`. It normalizes host, owner, and repository comparisons case-insensitively, constrains repository globs to one `*` within a path segment, and reports the winning rule and specificity. Equal-specificity rules selecting different profiles remain ambiguous; same-profile ties use the first configured rule and report it. Configuration validation no longer rejects broad rules before narrower rules because precedence is determined by the routing engine.

## Security / routing impact

Routing selects profile references only. It does not retrieve credentials, execute commands, call GitHub APIs, access MCP transport, or change global `gh` authentication state. Routing results contain no raw credential values. Ambiguous routes are explicit and cannot silently select an identity.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] Focused routing tests for all precedence levels, normalization, host separation, separator-safe globs, default/no-match, ambiguity, deterministic ties, and credential-free output.
- [x] `cargo run -- validate --config examples/config.example.yaml`

## Out of scope

- Credential discovery and retrieval (#4)
- Repository context discovery and write policy (#6)
- Upstream MCP sessions and request forwarding (#7, #8)
- CLI route/explain commands (#9)

Closes #5