### PR TITLE
ci: add essential Rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check compilation
+        run: cargo check --locked
+
+      - name: Run tests
+        run: cargo test --locked


### PR DESCRIPTION
## Summary
- add a minimal GitHub Actions workflow for pull requests and pushes to main
- run rustfmt, cargo check, and cargo test with Cargo.lock enforcement
- restrict workflow permissions to repository contents read access

## Validation
- cargo fmt --all -- --check
- cargo check --locked
- cargo test --locked