### PR TITLE
feat: resolve repository context and enforce safe writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,29 @@ The operation should fail instead of silently using a default account.
 
 Read operations may support explicitly configured fallback policies, but routing decisions must remain observable.
 
+### Repository context and write safety
+
+The router resolves repository context in this order, stopping at the first
+valid source:
+
+1. explicit `owner` and `repo` tool arguments;
+2. a full `owner/repository` argument;
+3. a GitHub repository URL;
+4. the request-scoped MCP root or workspace root's Git `origin` remote; and
+5. an explicitly configured default context.
+
+Common HTTPS, SCP-style SSH, and `ssh://` remotes are normalized to
+`host`, `owner`, `repository`, and a recorded source. Context discovery is
+read-only and never calls GitHub APIs. An explicit request wins over conflicting
+ambient context.
+
+Known read and write tools use separate operation classes. Unknown tools are
+treated conservatively. Ambiguous routes always fail closed; writes cannot use
+the default profile unless `ambiguity_policy.write: default_profile` is
+explicitly configured. Read fallback decisions record that the default profile
+was used. Missing or ambiguous repository context produces an actionable error
+instead of guessing an identity.
+
 ### Keep GitHub MCP upstream
 
 `gh-mcp-router` is not intended to implement GitHub Issues, Pull Requests, Actions, repositories, releases, or other GitHub APIs itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,8 +40,8 @@ remain separate concerns.
 | Module | Responsibility | Explicit non-responsibilities |
 | --- | --- | --- |
 | `config` | Serializable profile/route models, parsing, path expansion, and validation | Credential retrieval or routing evaluation |
-| `context` | Normalized repository identity | Git remote or MCP root discovery |
-| `routing` | Pure routing decision domain | Credential retrieval, API calls, CLI state |
+| `context` | Request-scoped repository resolution, normalization, and source metadata | Credential retrieval, routing policy, GitHub API calls |
+| `routing` | Pure routing decisions, operation classification, and safe fallback policy | Credential retrieval, API calls, CLI state |
 | `credentials` | Credential references, GitHub CLI account discovery, and token retrieval | Repository/profile routing or GitHub API calls |
 | `security` | Secret-safe formatting and `SecretString` cleanup | Full lifecycle hardening beyond value cleanup |
 | `mcp` | Client-facing protocol/proxy boundary | Repository routing policy |
@@ -76,8 +76,13 @@ capabilities rather than duplicate their definitions.
 - Credential retrieval and routing decisions remain separate concerns.
 - Ordinary `Debug` and `Display` formatting of secret values must redact them;
   subprocess output is never included in provider errors.
-- Ambiguous write operations will eventually fail closed rather than guess an
-  identity.
+- Ambiguous write operations fail closed rather than guess an identity.
+- Repository context prefers explicit tool arguments, then repository URLs,
+  request-scoped MCP/workspace roots, read-only Git remotes, and finally an
+  explicit configured context.
+- Default-profile fallback is allowed for reads by default, while write
+  fallback requires `ambiguity_policy.write: default_profile`; unknown tools
+  never use a default fallback.
 
 These are design principles. The GitHub CLI provider performs account discovery
 and on-demand token retrieval through explicit subprocess arguments and
@@ -91,7 +96,7 @@ The next features add behavior behind the boundaries established here:
 - configuration parsing and validation (`#3`, implemented)
 - GitHub CLI credential discovery (`#4`)
 - deterministic routing evaluation (`#5`, implemented)
-- repository context discovery and safe write policy (`#6`)
+- repository context discovery and safe write policy (`#6`, implemented)
 - profile-isolated upstream sessions (`#7`)
 - MCP request forwarding (`#8`)
 - complete CLI workflows (`#9`)

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,25 +1,59 @@
-//! Normalized repository context.
+//! Repository-context discovery and normalization.
 //!
-//! This boundary describes repository identity after a future discovery step.
-//! Git remote parsing, MCP root discovery, and fallback selection are deferred.
+//! Context discovery is deliberately independent from credentials and routing.
+//! It only answers which GitHub repository a request targets. The resolver
+//! uses request-scoped inputs first and inspects Git read-only when an explicit
+//! MCP/workspace root is supplied.
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Where normalized repository context came from.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ContextSource {
-    /// Context supplied explicitly by a caller.
-    Explicit,
-    /// Context discovered from an MCP workspace or root.
-    McpWorkspace,
-    /// Context discovered from a local Git remote.
-    LocalGit,
-    /// Context supplied by an explicit configured fallback.
-    ConfiguredFallback,
+    /// An owner/repository pair or full repository name supplied by a tool.
+    ToolArguments,
+    /// A GitHub repository URL supplied by a tool.
+    RepositoryUrl,
+    /// A repository discovered from an MCP root or workspace path.
+    McpRoot,
+    /// A repository discovered from the Git remote at an MCP root.
+    GitRemote,
+    /// An explicitly configured session/default context.
+    Default,
+}
+
+impl ContextSource {
+    // Keep the foundation names source-compatible for callers from #2/#3.
+    #[allow(non_upper_case_globals)]
+    pub const Explicit: Self = Self::ToolArguments;
+    #[allow(non_upper_case_globals)]
+    pub const McpWorkspace: Self = Self::McpRoot;
+    #[allow(non_upper_case_globals)]
+    pub const LocalGit: Self = Self::GitRemote;
+    #[allow(non_upper_case_globals)]
+    pub const ConfiguredFallback: Self = Self::Default;
+}
+
+impl fmt::Display for ContextSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ToolArguments => "tool-arguments",
+            Self::RepositoryUrl => "repository-url",
+            Self::McpRoot => "mcp-root",
+            Self::GitRemote => "git-remote",
+            Self::Default => "default",
+        })
+    }
 }
 
 /// Repository identity consumed by routing decisions.
 ///
-/// This type contains no authentication state and can therefore be created and
-/// passed through the application independently of credential handling.
+/// The constructor trims values and normalizes the host. Authentication state
+/// is intentionally absent, so this type can safely cross domain boundaries.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RepositoryContext {
     pub host: String,
@@ -29,7 +63,6 @@ pub struct RepositoryContext {
 }
 
 impl RepositoryContext {
-    /// Construct normalized context without performing discovery.
     pub fn new(
         host: impl Into<String>,
         owner: impl Into<String>,
@@ -37,30 +70,512 @@ impl RepositoryContext {
         source: ContextSource,
     ) -> Self {
         Self {
-            host: host.into(),
-            owner: owner.into(),
-            repository: repository.into(),
+            host: host.into().trim().to_ascii_lowercase(),
+            owner: owner.into().trim().to_owned(),
+            repository: repository.into().trim().to_owned(),
             source,
         }
+    }
+
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.repository)
+    }
+
+    pub fn from_owner_repo(owner: &str, repository: &str) -> Result<Self, ContextError> {
+        context_from_owner_repo(owner, repository, ContextSource::ToolArguments)
+    }
+
+    pub fn from_full_name(value: &str) -> Result<Self, ContextError> {
+        parse_full_name(value, ContextSource::ToolArguments)
+    }
+
+    pub fn from_repository_url(value: &str) -> Result<Self, ContextError> {
+        parse_repository_reference(value, ContextSource::RepositoryUrl)
+    }
+
+    pub fn from_git_remote(value: &str) -> Result<Self, ContextError> {
+        parse_repository_reference(value, ContextSource::GitRemote)
+    }
+}
+
+/// Request-scoped inputs considered by [`RepositoryContextResolver`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RepositoryContextRequest {
+    /// Explicit owner and repository tool arguments. `repo` may also contain
+    /// a full `owner/repository` name when `owner` is omitted.
+    pub owner: Option<String>,
+    pub repo: Option<String>,
+    /// A full `owner/repository` tool argument.
+    pub repository: Option<String>,
+    /// A GitHub repository URL tool argument.
+    pub repository_url: Option<String>,
+    /// The request-scoped MCP root. This is preferred over workspace_root.
+    pub mcp_root: Option<PathBuf>,
+    /// A workspace root supplied by the client or host.
+    pub workspace_root: Option<PathBuf>,
+    /// An explicitly configured context used as the final fallback.
+    pub configured_context: Option<RepositoryContext>,
+}
+
+impl RepositoryContextRequest {
+    pub fn owner_repo(owner: impl Into<String>, repo: impl Into<String>) -> Self {
+        Self {
+            owner: Some(owner.into()),
+            repo: Some(repo.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn repository(value: impl Into<String>) -> Self {
+        Self {
+            repository: Some(value.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn url(value: impl Into<String>) -> Self {
+        Self {
+            repository_url: Some(value.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_mcp_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.mcp_root = Some(root.into());
+        self
+    }
+
+    pub fn with_workspace_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = Some(root.into());
+        self
+    }
+
+    pub fn with_configured_context(mut self, context: RepositoryContext) -> Self {
+        self.configured_context = Some(context);
+        self
+    }
+}
+
+/// Errors produced while resolving request context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContextError {
+    MissingRepositoryContext,
+    IncompleteExplicitArguments,
+    InvalidRepository {
+        source: ContextSource,
+        message: String,
+    },
+    GitInspection {
+        root: PathBuf,
+        message: String,
+    },
+}
+
+impl fmt::Display for ContextError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRepositoryContext => formatter.write_str(
+                "repository context is missing; provide owner/repository or configure a matching route",
+            ),
+            Self::IncompleteExplicitArguments => formatter.write_str(
+                "owner and repo must be provided together, or repo must be a full owner/repository name",
+            ),
+            Self::InvalidRepository { source, message } => {
+                write!(formatter, "invalid repository context from {source}: {message}")
+            }
+            Self::GitInspection { root, message } => {
+                write!(formatter, "cannot inspect Git repository '{}': {message}", root.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ContextError {}
+
+/// Read-only provider for the origin URL of a workspace.
+pub trait GitRemoteProvider {
+    fn origin_url(&self, root: &Path) -> Result<Option<String>, ContextError>;
+}
+
+/// Git implementation used by the application.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CommandGitRemoteProvider;
+
+impl GitRemoteProvider for CommandGitRemoteProvider {
+    fn origin_url(&self, root: &Path) -> Result<Option<String>, ContextError> {
+        let root_arg = root.to_string_lossy().into_owned();
+        let output = Command::new("git")
+            .args(["-C", root_arg.as_str(), "remote", "get-url", "origin"])
+            .output()
+            .map_err(|error| ContextError::GitInspection {
+                root: root.to_owned(),
+                message: error.to_string(),
+            })?;
+
+        if !output.status.success() {
+            // A workspace without an origin is a valid discovery miss. Other
+            // Git failures remain visible so malformed/unsupported state cannot
+            // silently become an identity guess.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("No such remote")
+                || stderr.contains("not a git repository")
+                || stderr.contains("No such file or directory")
+            {
+                return Ok(None);
+            }
+            return Err(ContextError::GitInspection {
+                root: root.to_owned(),
+                message: "git could not read the origin remote".to_owned(),
+            });
+        }
+
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        Ok((!url.is_empty()).then_some(url))
+    }
+}
+
+/// Resolves a repository using explicit request data before ambient context.
+pub struct RepositoryContextResolver<P = CommandGitRemoteProvider> {
+    git: P,
+}
+
+impl Default for RepositoryContextResolver<CommandGitRemoteProvider> {
+    fn default() -> Self {
+        Self::new(CommandGitRemoteProvider)
+    }
+}
+
+impl<P: GitRemoteProvider> RepositoryContextResolver<P> {
+    pub fn new(git: P) -> Self {
+        Self { git }
+    }
+
+    /// Apply the Issue #6 precedence order:
+    /// owner+repo, full name, URL, MCP/workspace root, Git remote, default.
+    pub fn resolve(
+        &self,
+        request: &RepositoryContextRequest,
+    ) -> Result<RepositoryContext, ContextError> {
+        if request.owner.is_some() || request.repo.is_some() {
+            return match (request.owner.as_deref(), request.repo.as_deref()) {
+                (Some(owner), Some(repo)) => {
+                    context_from_owner_repo(owner, repo, ContextSource::ToolArguments)
+                }
+                (None, Some(repo)) if repo.contains('/') => {
+                    parse_full_name(repo, ContextSource::ToolArguments)
+                }
+                _ => Err(ContextError::IncompleteExplicitArguments),
+            };
+        }
+
+        if let Some(repository) = request.repository.as_deref() {
+            return parse_full_name(repository, ContextSource::ToolArguments);
+        }
+
+        if let Some(url) = request.repository_url.as_deref() {
+            return parse_repository_reference(url, ContextSource::RepositoryUrl);
+        }
+
+        if let Some(root) = request
+            .mcp_root
+            .as_deref()
+            .or(request.workspace_root.as_deref())
+        {
+            if let Some(remote) = self.git.origin_url(root)? {
+                return parse_repository_reference(&remote, ContextSource::GitRemote);
+            }
+        }
+
+        if let Some(context) = &request.configured_context {
+            return Ok(RepositoryContext::new(
+                &context.host,
+                &context.owner,
+                &context.repository,
+                ContextSource::Default,
+            ));
+        }
+
+        Err(ContextError::MissingRepositoryContext)
+    }
+}
+
+fn context_from_owner_repo(
+    owner: &str,
+    repo: &str,
+    source: ContextSource,
+) -> Result<RepositoryContext, ContextError> {
+    if repo.contains('/') {
+        return Err(invalid(
+            source,
+            "repo must be a repository name when owner is supplied",
+        ));
+    }
+    context_from_parts("github.com", owner, repo, source)
+}
+
+fn parse_full_name(value: &str, source: ContextSource) -> Result<RepositoryContext, ContextError> {
+    let Some((owner, repository)) = value.trim().split_once('/') else {
+        return Err(invalid(source, "expected owner/repository"));
+    };
+    if repository.contains('/') {
+        return Err(invalid(source, "expected exactly one path separator"));
+    }
+    context_from_parts("github.com", owner, repository, source)
+}
+
+fn parse_repository_reference(
+    value: &str,
+    source: ContextSource,
+) -> Result<RepositoryContext, ContextError> {
+    let value = value.trim();
+    if value.starts_with("git@") {
+        let Some((user, remainder)) = value.split_once('@') else {
+            return Err(invalid(source, "malformed SSH remote"));
+        };
+        if user.is_empty() {
+            return Err(invalid(source, "malformed SSH remote"));
+        }
+        let Some((host, path)) = remainder.split_once(':') else {
+            return Err(invalid(source, "malformed SSH remote"));
+        };
+        return parse_host_path(host, path, source);
+    }
+
+    if let Some(remainder) = value.strip_prefix("ssh://") {
+        let Some((authority, path)) = remainder.split_once('/') else {
+            return Err(invalid(source, "malformed SSH URL"));
+        };
+        let host = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        return parse_host_path(host, path, source);
+    }
+
+    for scheme in ["https://", "http://"] {
+        if let Some(remainder) = value.strip_prefix(scheme) {
+            if remainder.contains('?') || remainder.contains('#') {
+                return Err(invalid(
+                    source,
+                    "repository URL must not contain a query or fragment",
+                ));
+            }
+            let Some((authority, path)) = remainder.split_once('/') else {
+                return Err(invalid(
+                    source,
+                    "repository URL is missing owner/repository",
+                ));
+            };
+            let host = authority
+                .rsplit_once('@')
+                .map_or(authority, |(_, host)| host);
+            return parse_host_path(host, path, source);
+        }
+    }
+
+    parse_full_name(value, source)
+}
+
+fn parse_host_path(
+    host: &str,
+    path: &str,
+    source: ContextSource,
+) -> Result<RepositoryContext, ContextError> {
+    let path = path.trim_start_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let Some((owner, repository)) = path.split_once('/') else {
+        return Err(invalid(source, "expected owner/repository"));
+    };
+    if repository.contains('/') {
+        return Err(invalid(source, "expected exactly one repository path"));
+    }
+    context_from_parts(host, owner, repository, source)
+}
+
+fn context_from_parts(
+    host: &str,
+    owner: &str,
+    repository: &str,
+    source: ContextSource,
+) -> Result<RepositoryContext, ContextError> {
+    let host = host.trim();
+    let owner = owner.trim();
+    let repository = repository.trim();
+    if !valid_host(host) {
+        return Err(invalid(source, "host is malformed"));
+    }
+    if !valid_component(owner) || !valid_component(repository) {
+        return Err(invalid(
+            source,
+            "owner and repository must be non-empty path components",
+        ));
+    }
+    Ok(RepositoryContext::new(host, owner, repository, source))
+}
+
+fn valid_host(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|label| {
+            !label.is_empty()
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '-')
+        })
+}
+
+fn valid_component(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains('/')
+        && !value.contains('\\')
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+}
+
+fn invalid(source: ContextSource, message: impl Into<String>) -> ContextError {
+    ContextError::InvalidRepository {
+        source,
+        message: message.into(),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ContextSource, RepositoryContext};
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct FakeGit {
+        url: Option<String>,
+    }
+
+    impl GitRemoteProvider for FakeGit {
+        fn origin_url(&self, _root: &Path) -> Result<Option<String>, ContextError> {
+            Ok(self.url.clone())
+        }
+    }
+
+    fn resolver(url: Option<&str>) -> RepositoryContextResolver<FakeGit> {
+        RepositoryContextResolver::new(FakeGit {
+            url: url.map(str::to_owned),
+        })
+    }
 
     #[test]
-    fn repository_context_is_constructible_without_authentication() {
-        let context = RepositoryContext::new(
-            "github.com",
-            "ExampleOrg",
-            "backend",
-            ContextSource::Explicit,
-        );
-
+    fn resolves_owner_and_repo_arguments() {
+        let context = resolver(None)
+            .resolve(&RepositoryContextRequest::owner_repo(
+                "ExampleOrg",
+                "project",
+            ))
+            .unwrap();
         assert_eq!(context.host, "github.com");
         assert_eq!(context.owner, "ExampleOrg");
-        assert_eq!(context.repository, "backend");
-        assert_eq!(context.source, ContextSource::Explicit);
+        assert_eq!(context.repository, "project");
+        assert_eq!(context.source, ContextSource::ToolArguments);
+    }
+
+    #[test]
+    fn resolves_full_name_and_repository_url() {
+        let full = resolver(None)
+            .resolve(&RepositoryContextRequest::repository("ExampleOrg/project"))
+            .unwrap();
+        assert_eq!(full.source, ContextSource::ToolArguments);
+
+        let url = resolver(None)
+            .resolve(&RepositoryContextRequest::url(
+                "https://github.example.com/ExampleOrg/project.git",
+            ))
+            .unwrap();
+        assert_eq!(url.host, "github.example.com");
+        assert_eq!(url.source, ContextSource::RepositoryUrl);
+    }
+
+    #[test]
+    fn resolves_https_and_ssh_git_remotes() {
+        for remote in [
+            "https://github.com/ExampleOrg/project.git",
+            "git@github.com:ExampleOrg/project.git",
+            "ssh://git@github.example.com/ExampleOrg/project.git",
+        ] {
+            let context = resolver(Some(remote))
+                .resolve(&RepositoryContextRequest::default().with_mcp_root("/workspace"))
+                .unwrap();
+            assert_eq!(context.owner, "ExampleOrg");
+            assert_eq!(context.repository, "project");
+            assert_eq!(context.source, ContextSource::GitRemote);
+        }
+    }
+
+    #[test]
+    fn explicit_context_wins_over_conflicting_url_and_remote() {
+        let request = RepositoryContextRequest::owner_repo("ExplicitOrg", "explicit")
+            .with_mcp_root("/workspace");
+        let mut request = request;
+        request.repository_url = Some("https://github.com/OtherOrg/other".to_owned());
+        let context = resolver(Some("git@github.com:RemoteOrg/remote.git"))
+            .resolve(&request)
+            .unwrap();
+        assert_eq!(context.full_name(), "ExplicitOrg/explicit");
+        assert_eq!(context.source, ContextSource::ToolArguments);
+    }
+
+    #[test]
+    fn mcp_root_precedes_workspace_root_and_default() {
+        let request = RepositoryContextRequest::default()
+            .with_mcp_root("/mcp")
+            .with_workspace_root("/workspace")
+            .with_configured_context(RepositoryContext::new(
+                "github.com",
+                "DefaultOrg",
+                "default",
+                ContextSource::Explicit,
+            ));
+        let context = resolver(Some("git@github.com:McpOrg/mcp.git"))
+            .resolve(&request)
+            .unwrap();
+        assert_eq!(context.full_name(), "McpOrg/mcp");
+        assert_eq!(context.source, ContextSource::GitRemote);
+    }
+
+    #[test]
+    fn configured_context_is_the_final_fallback() {
+        let request =
+            RepositoryContextRequest::default().with_configured_context(RepositoryContext::new(
+                "github.com",
+                "ExampleOrg",
+                "project",
+                ContextSource::Explicit,
+            ));
+        let context = resolver(None).resolve(&request).unwrap();
+        assert_eq!(context.source, ContextSource::Default);
+    }
+
+    #[test]
+    fn incomplete_or_malformed_context_is_rejected() {
+        let error = resolver(None)
+            .resolve(&RepositoryContextRequest {
+                owner: Some("ExampleOrg".to_owned()),
+                ..RepositoryContextRequest::default()
+            })
+            .unwrap_err();
+        assert_eq!(error, ContextError::IncompleteExplicitArguments);
+
+        let error = resolver(None)
+            .resolve(&RepositoryContextRequest::url("git@github.com:bad"))
+            .unwrap_err();
+        assert!(error.to_string().contains("invalid repository context"));
+    }
+
+    #[test]
+    fn context_errors_do_not_echo_remote_values() {
+        let error = resolver(None)
+            .resolve(&RepositoryContextRequest::url(
+                "https://github.com/owner/invalid/repo?token=synthetic",
+            ))
+            .unwrap_err();
+        assert!(!error.to_string().contains("synthetic"));
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -19,6 +19,83 @@ pub enum OperationClass {
     Read,
     /// An operation that may change GitHub state.
     Write,
+    /// An operation whose safety cannot be established from maintained
+    /// upstream metadata.
+    Unknown,
+}
+
+impl fmt::Display for OperationClass {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Unknown => "unknown",
+        })
+    }
+}
+
+impl OperationClass {
+    /// Classify only names in maintained allowlists. New upstream tools remain
+    /// conservative until explicitly reviewed.
+    pub fn from_tool_name(name: &str) -> Self {
+        match name {
+            "get_file_contents"
+            | "get_repository"
+            | "get_issue"
+            | "list_issues"
+            | "search_issues"
+            | "get_pull_request"
+            | "list_pull_requests"
+            | "search_pull_requests"
+            | "search_code"
+            | "search_repositories"
+            | "get_commit"
+            | "list_commits"
+            | "list_branches"
+            | "list_tags"
+            | "get_release_by_tag"
+            | "list_releases"
+            | "get_workflow_run"
+            | "list_workflow_runs"
+            | "get_job_logs"
+            | "get_me"
+            | "get_project"
+            | "list_projects"
+            | "list_labels"
+            | "get_discussion"
+            | "list_discussions" => Self::Read,
+            "create_issue"
+            | "update_issue"
+            | "add_issue_comment"
+            | "create_pull_request"
+            | "update_pull_request"
+            | "merge_pull_request"
+            | "close_pull_request"
+            | "create_repository"
+            | "update_repository"
+            | "delete_repository"
+            | "create_or_update_file"
+            | "push_files"
+            | "delete_file"
+            | "create_branch"
+            | "delete_branch"
+            | "create_release"
+            | "update_release"
+            | "delete_release"
+            | "rerun_workflow"
+            | "cancel_workflow_run"
+            | "create_fork"
+            | "add_assignees"
+            | "remove_assignees"
+            | "add_labels"
+            | "remove_labels"
+            | "lock_issue"
+            | "unlock_issue"
+            | "update_pull_request_branch"
+            | "request_copilot_review" => Self::Write,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 /// Specificity used to compare otherwise matching route rules.
@@ -96,6 +173,66 @@ pub enum RoutingResult {
     NoMatch(NoMatch),
     Ambiguous(AmbiguousRouting),
 }
+
+/// A route selected after applying operation-specific safety policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafeRoutingDecision {
+    pub operation: OperationClass,
+    pub context: RepositoryContext,
+    pub routing: RoutingDecision,
+}
+
+/// Failure to safely associate an operation with one identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SafeRoutingError {
+    MissingRepositoryContext {
+        operation: OperationClass,
+    },
+    NoMatch {
+        operation: OperationClass,
+        repository: String,
+    },
+    Ambiguous {
+        operation: OperationClass,
+        route: AmbiguousRouting,
+    },
+    FallbackNotAllowed {
+        operation: OperationClass,
+        repository: String,
+    },
+}
+
+impl fmt::Display for SafeRoutingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRepositoryContext { operation } => write!(
+                formatter,
+                "Cannot safely select a GitHub identity for this {operation} operation. Repository context is missing or ambiguous. Provide owner/repository or configure a matching route."
+            ),
+            Self::NoMatch {
+                operation,
+                repository,
+            } => write!(
+                formatter,
+                "Cannot safely select a GitHub identity for this {operation} operation. No route matches {repository}; provide a matching route."
+            ),
+            Self::Ambiguous { operation, route } => write!(
+                formatter,
+                "Cannot safely select a GitHub identity for this {operation} operation. Routing for {} is ambiguous at {} specificity; configure one matching profile.",
+                route.repository, route.specificity
+            ),
+            Self::FallbackNotAllowed {
+                operation,
+                repository,
+            } => write!(
+                formatter,
+                "Cannot safely select a GitHub identity for this {operation} operation. The route for {repository} relies on a default profile, which is not permitted by the configured safety policy."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SafeRoutingError {}
 
 impl RoutingResult {
     pub fn selected_profile(&self) -> Option<&str> {
@@ -202,6 +339,59 @@ pub fn evaluate(config: &Config, context: &RepositoryContext) -> RoutingResult {
 /// Alias emphasizing that this function performs no external work.
 pub fn route(config: &Config, context: &RepositoryContext) -> RoutingResult {
     evaluate(config, context)
+}
+
+/// Apply routing and the conservative read/write/unknown fallback policy.
+///
+/// An explicit matching rule is sufficient for a known operation. A default
+/// profile is usable only when the corresponding policy explicitly permits it;
+/// unknown operations never use a default fallback. Ambiguous routes always
+/// fail closed.
+pub fn route_safely(
+    config: &Config,
+    context: Option<&RepositoryContext>,
+    operation: OperationClass,
+) -> Result<SafeRoutingDecision, SafeRoutingError> {
+    let context = context.ok_or(SafeRoutingError::MissingRepositoryContext { operation })?;
+    let result = evaluate(config, context);
+    let routing = match result {
+        RoutingResult::Selected(decision) => {
+            if decision.fallback_used && !fallback_allowed(config, operation) {
+                return Err(SafeRoutingError::FallbackNotAllowed {
+                    operation,
+                    repository: decision.repository,
+                });
+            }
+            decision
+        }
+        RoutingResult::NoMatch(no_match) => {
+            return Err(SafeRoutingError::NoMatch {
+                operation,
+                repository: no_match.repository,
+            })
+        }
+        RoutingResult::Ambiguous(route) => {
+            return Err(SafeRoutingError::Ambiguous { operation, route })
+        }
+    };
+
+    Ok(SafeRoutingDecision {
+        operation,
+        context: context.clone(),
+        routing,
+    })
+}
+
+fn fallback_allowed(config: &Config, operation: OperationClass) -> bool {
+    match operation {
+        OperationClass::Read => {
+            config.ambiguity_policy.read == crate::config::AmbiguityPolicy::DefaultProfile
+        }
+        OperationClass::Write => {
+            config.ambiguity_policy.write == crate::config::AmbiguityPolicy::DefaultProfile
+        }
+        OperationClass::Unknown => false,
+    }
 }
 
 fn repository_name(context: &RepositoryContext) -> String {
@@ -538,5 +728,111 @@ mod tests {
         let formatted = format!("{result:?}");
         assert!(!formatted.contains("ghp_"));
         assert!(!formatted.contains("github_pat_"));
+    }
+
+    #[test]
+    fn safe_routing_allows_explicit_write_route() {
+        let config = config(
+            vec![rule("work", Some("ExampleOrg/repo"), None, None)],
+            Some("personal"),
+        );
+        let decision = route_safely(
+            &config,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Write,
+        )
+        .unwrap();
+        assert_eq!(decision.routing.selected_profile, "work");
+        assert!(!decision.routing.fallback_used);
+    }
+
+    #[test]
+    fn safe_routing_rejects_unmatched_write_and_ambiguous_write() {
+        let no_route = config(Vec::new(), Some("personal"));
+        let error = route_safely(
+            &no_route,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Write,
+        )
+        .unwrap_err();
+        assert!(matches!(error, SafeRoutingError::FallbackNotAllowed { .. }));
+
+        let ambiguous = config(
+            vec![
+                rule("personal", Some("ExampleOrg/repo"), None, None),
+                rule("work", Some("ExampleOrg/repo"), None, None),
+            ],
+            None,
+        );
+        let error = route_safely(
+            &ambiguous,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Write,
+        )
+        .unwrap_err();
+        assert!(matches!(error, SafeRoutingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn safe_routing_allows_explicit_read_fallback_and_marks_it() {
+        let config = config(Vec::new(), Some("personal"));
+        let decision = route_safely(
+            &config,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Read,
+        )
+        .unwrap();
+        assert_eq!(decision.routing.selected_profile, "personal");
+        assert!(decision.routing.fallback_used);
+    }
+
+    #[test]
+    fn write_fallback_requires_and_honors_explicit_policy() {
+        let mut config = config(Vec::new(), Some("personal"));
+        config.ambiguity_policy.write = crate::config::AmbiguityPolicy::DefaultProfile;
+        let decision = route_safely(
+            &config,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Write,
+        )
+        .unwrap();
+        assert_eq!(decision.routing.selected_profile, "personal");
+        assert!(decision.routing.fallback_used);
+    }
+
+    #[test]
+    fn unknown_operations_never_use_default_fallback() {
+        let config = config(Vec::new(), Some("personal"));
+        let error = route_safely(
+            &config,
+            Some(&context("github.com", "ExampleOrg", "repo")),
+            OperationClass::Unknown,
+        )
+        .unwrap_err();
+        assert!(matches!(error, SafeRoutingError::FallbackNotAllowed { .. }));
+    }
+
+    #[test]
+    fn operation_classification_is_allowlist_based() {
+        assert_eq!(
+            OperationClass::from_tool_name("get_repository"),
+            OperationClass::Read
+        );
+        assert_eq!(
+            OperationClass::from_tool_name("create_issue"),
+            OperationClass::Write
+        );
+        assert_eq!(
+            OperationClass::from_tool_name("future_tool_with_update_in_name"),
+            OperationClass::Unknown
+        );
+    }
+
+    #[test]
+    fn missing_context_is_an_actionable_safe_routing_error() {
+        let error =
+            route_safely(&config(Vec::new(), None), None, OperationClass::Write).unwrap_err();
+        assert!(error.to_string().contains("owner/repository"));
+        assert!(!error.to_string().contains("ghp_"));
     }
 }


### PR DESCRIPTION
## Summary

- Resolve repository context from explicit tool arguments, repository names/URLs, MCP/workspace roots, Git remotes, and configured fallback context.
- Normalize HTTPS, SCP-style SSH, and `ssh://` repository references with source metadata.
- Enforce conservative routing for read, write, and unknown operations, including fail-closed ambiguous and unsafe default fallback cases.

## Implementation

Added an injectable `GitRemoteProvider` and a read-only command-backed implementation so context resolution is independently testable without GitHub API access. Resolver precedence is explicit request data, repository URL, request-scoped root, Git origin remote, then configured context. Routing now has an allowlist-based operation classifier and `route_safely` policy layer over the existing pure routing engine.

## Security / routing impact

Ambiguous routes always fail closed. Read fallback is allowed only by the configured read policy and records `fallback_used`; write fallback requires explicit `ambiguity_policy.write: default_profile`; unknown operations never use a default fallback. No credentials, GitHub API calls, global `gh` account state, or mutable current-account state were added.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] Context unit tests for owner/repo, full names, HTTPS/SSH URLs, MCP/workspace root to Git remote, precedence, defaults, malformed input, and redaction.
- [x] Safe-routing tests for explicit writes, unmatched/ambiguous writes, marked read fallback, explicit write fallback policy, unknown operations, and missing context.
- [x] Diff review and credential-pattern scan.

## Out of scope

- MCP transport/session management (#7/#8)
- CLI workflow and diagnostics (#9)
- Security/concurrency hardening beyond this routing policy (#10)

Closes #6
