### PR TITLE
#7 feat: add isolated GitHub MCP sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,11 @@ It should only be split into multiple crates when real architectural boundaries 
 
 ## Profile-isolated upstream sessions
 
-The preferred v0.1 local architecture is one isolated official GitHub MCP session per credential profile.
+The v0.1 local architecture uses one isolated official GitHub MCP stdio
+session per credential profile. The router starts sessions lazily and caches a
+healthy session for reuse. The default executable is `github-mcp-server stdio`;
+an explicit executable path or startup arguments can be supplied by the caller,
+and a missing executable is reported clearly rather than downloaded.
 
 ```text
                        ┌─────────────────────┐
@@ -288,6 +292,17 @@ MCP Client → Router -----+
 ```
 
 A session created for one profile must never be reused for another profile.
+Each session is permanently bound to its profile's non-secret credential
+reference. The resolved credential is passed only as
+`GITHUB_PERSONAL_ACCESS_TOKEN` in that child process's environment, alongside
+profile-specific host/config values when configured. It is never put in
+arguments or the router's global environment. Failed sessions are discarded
+without retrying the request and restarted on the next request; shutdown closes
+and terminates all child sessions.
+
+The upstream boundary forwards newline-delimited messages and does not define
+GitHub tools itself. Client-facing routing and MCP tool-surface preservation
+are handled by the follow-up MCP routing feature.
 
 HTTP upstream routing with request-scoped authorization may be explored later where appropriate, but it is not required for the first implementation.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,8 +65,11 @@ The router intentionally does **not** implement or replace the following:
 - a replacement GitHub MCP toolset
 
 Those capabilities remain responsibilities of the official GitHub MCP Server.
-The upstream process/session boundary will forward or isolate those
-capabilities rather than duplicate their definitions.
+The upstream process/session boundary forwards or isolates those capabilities
+rather than duplicate their definitions. It maintains one lazily started stdio
+child per profile, binds each child permanently to its credential reference,
+passes the resolved credential only in the child environment, and restarts a
+failed child on the next request without retrying the failed message.
 
 ## Security principles
 
@@ -86,8 +89,10 @@ capabilities rather than duplicate their definitions.
 
 These are design principles. The GitHub CLI provider performs account discovery
 and on-demand token retrieval through explicit subprocess arguments and
-profile-specific `GH_CONFIG_DIR` values. Repository inference, routing
-evaluation, and MCP proxying remain separate concerns.
+profile-specific `GH_CONFIG_DIR` values. The upstream launcher uses the
+configured `github-mcp-server` executable or PATH lookup and never inherits
+upstream stderr. Repository inference, routing evaluation, and MCP proxying
+remain separate concerns.
 
 ## Planned feature ownership
 
@@ -97,7 +102,7 @@ The next features add behavior behind the boundaries established here:
 - GitHub CLI credential discovery (`#4`)
 - deterministic routing evaluation (`#5`, implemented)
 - repository context discovery and safe write policy (`#6`, implemented)
-- profile-isolated upstream sessions (`#7`)
+- profile-isolated upstream sessions (`#7`, implemented)
 - MCP request forwarding (`#8`)
 - complete CLI workflows (`#9`)
 - deeper secret, concurrency, logging, and process hardening (`#10`)

--- a/src/upstream/mod.rs
+++ b/src/upstream/mod.rs
@@ -1,4 +1,799 @@
-//! Official GitHub MCP upstream session boundary.
+//! Profile-isolated sessions for the official GitHub MCP Server.
 //!
-//! Session management and process isolation are deferred. GitHub capability
-//! definitions remain owned by the official GitHub MCP Server.
+//! The router starts one local stdio process per configured profile. A session
+//! is permanently bound to the non-secret [`CredentialRef`] that created it;
+//! it is never reassigned when routing decisions change. The upstream process
+//! receives its credential through `GITHUB_PERSONAL_ACCESS_TOKEN` in its child
+//! environment, never through command-line arguments or the router's global
+//! environment.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    io::{BufRead, BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    credentials::{CredentialError, CredentialProvider, CredentialRef},
+    security::SecretString,
+};
+
+const DEFAULT_BINARY: &str = "github-mcp-server";
+const DEFAULT_START_ARGS: &[&str] = &["stdio"];
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Configuration for the official GitHub MCP stdio executable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpstreamConfig {
+    binary: PathBuf,
+    args: Vec<String>,
+}
+
+impl Default for UpstreamConfig {
+    fn default() -> Self {
+        Self {
+            binary: PathBuf::from(DEFAULT_BINARY),
+            args: DEFAULT_START_ARGS
+                .iter()
+                .map(|arg| (*arg).to_owned())
+                .collect(),
+        }
+    }
+}
+
+impl UpstreamConfig {
+    /// Use an explicit executable path, or a bare name resolved through PATH.
+    pub fn with_binary(mut self, binary: impl Into<PathBuf>) -> Self {
+        self.binary = binary.into();
+        self
+    }
+
+    /// Override the upstream startup arguments. The default is `stdio`.
+    pub fn with_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args = args.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn binary(&self) -> &Path {
+        &self.binary
+    }
+
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+/// Secret-bearing child-process environment values.
+///
+/// The launch request is consumed by a launcher. This makes it possible for
+/// the real launcher to hand the credential to the child and then drop the
+/// request, minimizing the time the token remains in router-owned memory.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UpstreamEnvironment(BTreeMap<String, SecretString>);
+
+impl fmt::Debug for UpstreamEnvironment {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_map()
+            .entries(self.0.keys().map(|key| (key, "[REDACTED]")))
+            .finish()
+    }
+}
+
+impl UpstreamEnvironment {
+    fn for_credential(reference: &CredentialRef, credential: SecretString) -> Self {
+        let mut values = BTreeMap::new();
+        values.insert("GITHUB_PERSONAL_ACCESS_TOKEN".to_owned(), credential);
+        if let Some(host) = reference.host() {
+            let host = if host.eq_ignore_ascii_case("github.com") {
+                "https://github.com".to_owned()
+            } else {
+                format!("https://{host}")
+            };
+            values.insert("GITHUB_HOST".to_owned(), SecretString::new(host));
+        }
+        if let Some(config_dir) = reference.gh_config_dir() {
+            values.insert("GH_CONFIG_DIR".to_owned(), SecretString::new(config_dir));
+        }
+        Self(values)
+    }
+
+    /// Explicitly inspect an environment value at the child-process boundary.
+    /// Ordinary formatting remains redacted.
+    pub fn get(&self, key: &str) -> Option<&SecretString> {
+        self.0.get(key)
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.0.keys().map(String::as_str)
+    }
+}
+
+/// Metadata and environment passed to an upstream launcher.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UpstreamLaunchRequest {
+    binary: PathBuf,
+    args: Vec<String>,
+    environment: UpstreamEnvironment,
+}
+
+impl fmt::Debug for UpstreamLaunchRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UpstreamLaunchRequest")
+            .field("binary", &self.binary)
+            .field("args", &self.args)
+            .field("environment", &self.environment)
+            .finish()
+    }
+}
+
+impl UpstreamLaunchRequest {
+    pub fn binary(&self) -> &Path {
+        &self.binary
+    }
+
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    /// Return the environment for an explicit launcher boundary inspection.
+    pub fn environment(&self) -> &UpstreamEnvironment {
+        &self.environment
+    }
+}
+
+/// Stable categories for upstream process failures.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpstreamProcessError {
+    Io,
+    Exited,
+    InvalidResponse,
+}
+
+impl fmt::Display for UpstreamProcessError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Io => "upstream process I/O failed",
+            Self::Exited => "upstream process exited",
+            Self::InvalidResponse => "upstream process returned an invalid response",
+        })
+    }
+}
+
+impl std::error::Error for UpstreamProcessError {}
+
+/// A running upstream process. Implementations must not include payloads or
+/// child stderr in errors, because upstream messages may contain sensitive
+/// data in future protocol versions.
+pub trait UpstreamProcess: Send {
+    fn send(&mut self, message: &str) -> Result<String, UpstreamProcessError>;
+    fn is_alive(&mut self) -> bool;
+    fn shutdown(&mut self);
+}
+
+/// Injectable process-launch boundary used by tests and alternate runtimes.
+pub trait UpstreamLauncher: Send + Sync {
+    fn launch(
+        &self,
+        request: UpstreamLaunchRequest,
+    ) -> Result<Box<dyn UpstreamProcess>, UpstreamLaunchError>;
+}
+
+/// Failures while creating an upstream process.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpstreamLaunchError {
+    BinaryNotFound { binary: PathBuf },
+    Io,
+}
+
+impl fmt::Display for UpstreamLaunchError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BinaryNotFound { binary } => {
+                write!(
+                    formatter,
+                    "GitHub MCP upstream binary '{}' was not found",
+                    binary.display()
+                )
+            }
+            Self::Io => formatter.write_str("GitHub MCP upstream process could not be started"),
+        }
+    }
+}
+
+impl std::error::Error for UpstreamLaunchError {}
+
+/// The production launcher for `github-mcp-server`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProcessUpstreamLauncher;
+
+impl UpstreamLauncher for ProcessUpstreamLauncher {
+    fn launch(
+        &self,
+        request: UpstreamLaunchRequest,
+    ) -> Result<Box<dyn UpstreamProcess>, UpstreamLaunchError> {
+        let mut command = Command::new(&request.binary);
+        command.args(&request.args);
+        for (key, value) in &request.environment.0 {
+            command.env(key, value.expose());
+        }
+        // Never inherit stderr: the upstream process may print sensitive
+        // diagnostics and the router must not accidentally expose them.
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+
+        let mut child = command.spawn().map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                UpstreamLaunchError::BinaryNotFound {
+                    binary: request.binary.clone(),
+                }
+            } else {
+                UpstreamLaunchError::Io
+            }
+        })?;
+        let Some(stdin) = child.stdin.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(UpstreamLaunchError::Io);
+        };
+        let Some(stdout) = child.stdout.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(UpstreamLaunchError::Io);
+        };
+
+        Ok(Box::new(ProcessUpstreamSession {
+            child,
+            stdin: Some(BufWriter::new(stdin)),
+            stdout: BufReader::new(stdout),
+        }))
+    }
+}
+
+struct ProcessUpstreamSession {
+    child: Child,
+    stdin: Option<BufWriter<ChildStdin>>,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl UpstreamProcess for ProcessUpstreamSession {
+    fn send(&mut self, message: &str) -> Result<String, UpstreamProcessError> {
+        if !self.is_alive() {
+            return Err(UpstreamProcessError::Exited);
+        }
+        let stdin = self.stdin.as_mut().ok_or(UpstreamProcessError::Exited)?;
+        stdin
+            .write_all(message.as_bytes())
+            .map_err(|_| UpstreamProcessError::Io)?;
+        if !message.ends_with('\n') {
+            stdin
+                .write_all(b"\n")
+                .map_err(|_| UpstreamProcessError::Io)?;
+        }
+        stdin.flush().map_err(|_| UpstreamProcessError::Io)?;
+
+        let mut response = String::new();
+        let bytes = self
+            .stdout
+            .read_line(&mut response)
+            .map_err(|_| UpstreamProcessError::Io)?;
+        if bytes == 0 {
+            return Err(UpstreamProcessError::Exited);
+        }
+        let response = response.trim_end_matches(['\r', '\n']);
+        if response.is_empty() {
+            return Err(UpstreamProcessError::InvalidResponse);
+        }
+        Ok(response.to_owned())
+    }
+
+    fn is_alive(&mut self) -> bool {
+        self.child
+            .try_wait()
+            .map(|status| status.is_none())
+            .unwrap_or(false)
+    }
+
+    fn shutdown(&mut self) {
+        // Closing stdin gives a well-behaved stdio server a chance to exit.
+        self.stdin.take();
+        let started = Instant::now();
+        while started.elapsed() < SHUTDOWN_TIMEOUT {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(10)),
+                Err(_) => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ProcessUpstreamSession {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// A public snapshot of the manager's lifecycle state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub profile: String,
+    pub active: bool,
+}
+
+/// Errors returned by the profile session manager.
+#[derive(Debug)]
+pub enum UpstreamError {
+    Credential(CredentialError),
+    Launch(UpstreamLaunchError),
+    Process(UpstreamProcessError),
+    ProfileIdentityMismatch { profile: String },
+}
+
+impl fmt::Display for UpstreamError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Credential(error) => error.fmt(formatter),
+            Self::Launch(error) => error.fmt(formatter),
+            Self::Process(error) => error.fmt(formatter),
+            Self::ProfileIdentityMismatch { profile } => write!(
+                formatter,
+                "profile '{profile}' is already bound to a different credential reference"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UpstreamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Credential(error) => Some(error),
+            Self::Launch(error) => Some(error),
+            Self::Process(error) => Some(error),
+            Self::ProfileIdentityMismatch { .. } => None,
+        }
+    }
+}
+
+struct ManagedSession {
+    credential: CredentialRef,
+    process: Option<Box<dyn UpstreamProcess>>,
+}
+
+/// Lazily creates and caches one upstream session per configured profile.
+///
+/// The map lock only protects session lookup. Each profile has its own lock,
+/// so different profiles may start and serve concurrently while same-profile
+/// startup is serialized and cannot spawn duplicate children.
+pub struct UpstreamSessionManager<C, L = ProcessUpstreamLauncher> {
+    credential_provider: C,
+    launcher: L,
+    config: UpstreamConfig,
+    sessions: Mutex<BTreeMap<String, Arc<Mutex<ManagedSession>>>>,
+}
+
+impl<C, L> UpstreamSessionManager<C, L> {
+    pub fn new(credential_provider: C, launcher: L, config: UpstreamConfig) -> Self {
+        Self {
+            credential_provider,
+            launcher,
+            config,
+            sessions: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub fn session_count(&self) -> usize {
+        self.sessions
+            .lock()
+            .expect("session map lock poisoned")
+            .len()
+    }
+
+    pub fn session_info(&self) -> Vec<SessionInfo> {
+        self.sessions
+            .lock()
+            .expect("session map lock poisoned")
+            .iter()
+            .map(|(profile, session)| SessionInfo {
+                profile: profile.clone(),
+                active: session
+                    .lock()
+                    .expect("session lock poisoned")
+                    .process
+                    .as_mut()
+                    .is_some_and(|process| process.is_alive()),
+            })
+            .collect()
+    }
+}
+
+impl<C: CredentialProvider + Send + Sync, L: UpstreamLauncher> UpstreamSessionManager<C, L> {
+    /// Start or reuse the session bound to `profile` and `credential`.
+    pub fn start(
+        &self,
+        profile: impl Into<String>,
+        credential: &CredentialRef,
+    ) -> Result<SessionInfo, UpstreamError> {
+        let profile = profile.into();
+        let session = self.session_for(&profile, credential)?;
+        let mut session = session.lock().expect("session lock poisoned");
+        self.ensure_process(&mut session)?;
+        Ok(SessionInfo {
+            profile,
+            active: true,
+        })
+    }
+
+    /// Send one newline-delimited MCP message through a profile's session.
+    ///
+    /// A failed request is not retried: a write could have reached the
+    /// upstream process before its response failed. The process is discarded,
+    /// and the next request starts a fresh session safely.
+    pub fn send(
+        &self,
+        profile: impl Into<String>,
+        credential: &CredentialRef,
+        message: &str,
+    ) -> Result<String, UpstreamError> {
+        let profile = profile.into();
+        let session = self.session_for(&profile, credential)?;
+        let mut session = session.lock().expect("session lock poisoned");
+        self.ensure_process(&mut session)?;
+        let result = session
+            .process
+            .as_mut()
+            .expect("ensure_process installs a process")
+            .send(message);
+        match result {
+            Ok(response) => Ok(response),
+            Err(error) => {
+                session.process.take();
+                Err(UpstreamError::Process(error))
+            }
+        }
+    }
+
+    /// Shut down every child and remove all cached sessions.
+    pub fn shutdown(&self) {
+        let sessions =
+            std::mem::take(&mut *self.sessions.lock().expect("session map lock poisoned"));
+        for session in sessions.into_values() {
+            if let Ok(mut session) = session.lock() {
+                if let Some(process) = session.process.as_mut() {
+                    process.shutdown();
+                }
+                session.process.take();
+            }
+        }
+    }
+
+    fn session_for(
+        &self,
+        profile: &str,
+        credential: &CredentialRef,
+    ) -> Result<Arc<Mutex<ManagedSession>>, UpstreamError> {
+        let mut sessions = self.sessions.lock().expect("session map lock poisoned");
+        if let Some(session) = sessions.get(profile) {
+            if session.lock().expect("session lock poisoned").credential != *credential {
+                return Err(UpstreamError::ProfileIdentityMismatch {
+                    profile: profile.to_owned(),
+                });
+            }
+            return Ok(Arc::clone(session));
+        }
+        let session = Arc::new(Mutex::new(ManagedSession {
+            credential: credential.clone(),
+            process: None,
+        }));
+        sessions.insert(profile.to_owned(), Arc::clone(&session));
+        Ok(session)
+    }
+
+    fn ensure_process(&self, session: &mut ManagedSession) -> Result<(), UpstreamError> {
+        if session
+            .process
+            .as_mut()
+            .is_some_and(|process| process.is_alive())
+        {
+            return Ok(());
+        }
+        session.process.take();
+
+        let secret = self
+            .credential_provider
+            .resolve(&session.credential)
+            .map_err(UpstreamError::Credential)?;
+        let request = UpstreamLaunchRequest {
+            binary: self.config.binary.clone(),
+            args: self.config.args.clone(),
+            environment: UpstreamEnvironment::for_credential(&session.credential, secret),
+        };
+        session.process = Some(
+            self.launcher
+                .launch(request)
+                .map_err(UpstreamError::Launch)?,
+        );
+        Ok(())
+    }
+}
+
+impl<C, L> Drop for UpstreamSessionManager<C, L> {
+    fn drop(&mut self) {
+        let sessions = std::mem::take(self.sessions.get_mut().expect("session map lock poisoned"));
+        for session in sessions.into_values() {
+            if let Ok(mut session) = session.lock() {
+                if let Some(process) = session.process.as_mut() {
+                    process.shutdown();
+                }
+                session.process.take();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+        thread,
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeCredentials {
+        values: Arc<HashMap<String, String>>,
+    }
+
+    impl FakeCredentials {
+        fn new(values: [(&str, &str); 2]) -> Self {
+            Self {
+                values: Arc::new(
+                    values
+                        .into_iter()
+                        .map(|(profile, token)| (profile.to_owned(), token.to_owned()))
+                        .collect(),
+                ),
+            }
+        }
+    }
+
+    impl CredentialProvider for FakeCredentials {
+        fn resolve(&self, reference: &CredentialRef) -> Result<SecretString, CredentialError> {
+            self.values
+                .get(reference.name())
+                .cloned()
+                .map(SecretString::new)
+                .ok_or_else(|| {
+                    CredentialError::new(
+                        reference.clone(),
+                        crate::credentials::CredentialErrorKind::Unavailable,
+                    )
+                })
+        }
+    }
+
+    struct FakeProcess {
+        alive: bool,
+        fail_next_send: Arc<AtomicBool>,
+        shutdowns: Arc<AtomicUsize>,
+    }
+
+    impl UpstreamProcess for FakeProcess {
+        fn send(&mut self, message: &str) -> Result<String, UpstreamProcessError> {
+            if self.fail_next_send.swap(false, Ordering::SeqCst) {
+                self.alive = false;
+                return Err(UpstreamProcessError::Io);
+            }
+            Ok(format!(r#"{{"jsonrpc":"2.0","result":"{message}"}}"#))
+        }
+
+        fn is_alive(&mut self) -> bool {
+            self.alive
+        }
+
+        fn shutdown(&mut self) {
+            self.alive = false;
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeLauncher {
+        requests: Arc<Mutex<Vec<UpstreamLaunchRequest>>>,
+        launches: Arc<AtomicUsize>,
+        shutdowns: Arc<AtomicUsize>,
+        fail_next_send: Arc<AtomicBool>,
+    }
+
+    impl FakeLauncher {
+        fn new() -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                launches: Arc::new(AtomicUsize::new(0)),
+                shutdowns: Arc::new(AtomicUsize::new(0)),
+                fail_next_send: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    impl UpstreamLauncher for FakeLauncher {
+        fn launch(
+            &self,
+            request: UpstreamLaunchRequest,
+        ) -> Result<Box<dyn UpstreamProcess>, UpstreamLaunchError> {
+            self.requests.lock().unwrap().push(request);
+            self.launches.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(FakeProcess {
+                alive: true,
+                fail_next_send: Arc::clone(&self.fail_next_send),
+                shutdowns: Arc::clone(&self.shutdowns),
+            }))
+        }
+    }
+
+    fn manager() -> (
+        UpstreamSessionManager<FakeCredentials, FakeLauncher>,
+        FakeLauncher,
+    ) {
+        let credentials = FakeCredentials::new([
+            ("personal", "ghp_PERSONAL_SYNTHETIC"),
+            ("work", "github_pat_WORK_SYNTHETIC"),
+        ]);
+        let launcher = FakeLauncher::new();
+        let manager = UpstreamSessionManager::new(
+            credentials,
+            launcher.clone(),
+            UpstreamConfig::default().with_binary("fake-github-mcp-server"),
+        );
+        (manager, launcher)
+    }
+
+    fn reference(profile: &str) -> CredentialRef {
+        CredentialRef::new("gh", profile).with_host("github.com")
+    }
+
+    #[test]
+    fn starts_two_profile_isolated_sessions_without_token_arguments() {
+        let (manager, launcher) = manager();
+
+        manager.start("personal", &reference("personal")).unwrap();
+        manager.start("personal", &reference("personal")).unwrap();
+        manager.start("work", &reference("work")).unwrap();
+
+        assert_eq!(manager.session_count(), 2);
+        assert_eq!(launcher.launches.load(Ordering::SeqCst), 2);
+        let requests = launcher.requests.lock().unwrap();
+        let personal = requests[0]
+            .environment()
+            .get("GITHUB_PERSONAL_ACCESS_TOKEN")
+            .unwrap();
+        let work = requests[1]
+            .environment()
+            .get("GITHUB_PERSONAL_ACCESS_TOKEN")
+            .unwrap();
+        assert_eq!(personal.expose(), "ghp_PERSONAL_SYNTHETIC");
+        assert_eq!(work.expose(), "github_pat_WORK_SYNTHETIC");
+        assert_eq!(
+            requests[0]
+                .environment()
+                .get("GITHUB_HOST")
+                .unwrap()
+                .expose(),
+            "https://github.com"
+        );
+        assert!(!format!("{requests:?}").contains("ghp_PERSONAL_SYNTHETIC"));
+        assert!(requests.iter().all(|request| request
+            .args()
+            .iter()
+            .all(|arg| { !arg.contains("ghp_") && !arg.contains("github_pat_") })));
+    }
+
+    #[test]
+    fn same_profile_concurrency_reuses_one_session() {
+        let (manager, launcher) = manager();
+        let manager = Arc::new(manager);
+        let credential = reference("personal");
+        let handles = (0..8)
+            .map(|index| {
+                let manager = Arc::clone(&manager);
+                let credential = credential.clone();
+                thread::spawn(move || {
+                    manager.send("personal", &credential, &format!("message-{index}"))
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            assert!(handle.join().unwrap().is_ok());
+        }
+        assert_eq!(launcher.launches.load(Ordering::SeqCst), 1);
+        assert!(manager.session_info()[0].active);
+    }
+
+    #[test]
+    fn failed_process_is_restarted_without_retrying_the_failed_message() {
+        let (manager, launcher) = manager();
+        launcher.fail_next_send.store(true, Ordering::SeqCst);
+        let credential = reference("personal");
+
+        assert!(matches!(
+            manager.send("personal", &credential, "write-once"),
+            Err(UpstreamError::Process(UpstreamProcessError::Io))
+        ));
+        assert!(manager
+            .send("personal", &credential, "retry-after-restart")
+            .is_ok());
+        assert_eq!(launcher.launches.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn profile_cannot_be_rebound_to_a_different_credential_reference() {
+        let (manager, _launcher) = manager();
+        manager.start("personal", &reference("personal")).unwrap();
+
+        let error = manager.start("personal", &reference("work")).unwrap_err();
+        assert!(
+            matches!(error, UpstreamError::ProfileIdentityMismatch { profile } if profile == "personal")
+        );
+    }
+
+    #[test]
+    fn shutdown_terminates_all_sessions_and_clears_cache() {
+        let (manager, launcher) = manager();
+        manager.start("personal", &reference("personal")).unwrap();
+        manager.start("work", &reference("work")).unwrap();
+
+        manager.shutdown();
+
+        assert_eq!(manager.session_count(), 0);
+        assert_eq!(launcher.shutdowns.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn launch_request_debug_redacts_all_environment_values() {
+        let (manager, launcher) = manager();
+        manager.start("personal", &reference("personal")).unwrap();
+        let requests = launcher.requests.lock().unwrap();
+        let debug = format!("{requests:?}");
+        assert!(debug.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+        assert!(!debug.contains("SYNTHETIC"));
+    }
+
+    #[test]
+    fn process_launcher_reports_missing_explicit_binary() {
+        let launcher = ProcessUpstreamLauncher;
+        let request = UpstreamLaunchRequest {
+            binary: PathBuf::from("/definitely/missing/github-mcp-server"),
+            args: vec!["stdio".to_owned()],
+            environment: UpstreamEnvironment::for_credential(
+                &reference("personal"),
+                SecretString::new("ghp_SYNTHETIC"),
+            ),
+        };
+
+        let error = match launcher.launch(request) {
+            Ok(_) => panic!("missing binary unexpectedly launched"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, UpstreamLaunchError::BinaryNotFound { .. }));
+        assert!(!error.to_string().contains("ghp_SYNTHETIC"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add one lazily managed stdio GitHub MCP session per profile.
- Inject profile credentials only into the child environment.
- Add restart, reuse, identity-binding, shutdown, and redaction coverage.

## Implementation

The upstream boundary provides an injectable launcher/process abstraction and a production stdio launcher for `github-mcp-server stdio`. Sessions are cached by profile and permanently bound to their non-secret `CredentialRef`. Same-profile startup is serialized; failed processes are discarded without retrying the request and recreated on the next request. The official server remains responsible for MCP and GitHub tool behavior.

## Security / routing impact

Credentials are passed only as `GITHUB_PERSONAL_ACCESS_TOKEN` in the child environment. They are never placed in command-line arguments or the router's global environment. Profile-specific `GITHUB_HOST` and `GH_CONFIG_DIR` values are preserved. Upstream stderr is not inherited, and launch-request formatting redacts environment values. A profile cannot be rebound to a different credential reference.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] Fake two-profile credential/session isolation.
- [x] Same-profile concurrent reuse without duplicate launches.
- [x] Failed-session restart without request retry.
- [x] Missing-binary error handling.
- [x] Clean shutdown and cache clearing.
- [x] Redaction and no-token-argument assertions.

## Out of scope

- Client-facing MCP routing and tool-surface forwarding (Issue #8).
- CLI workflow, broader hardening, integration matrix, and release work.

Closes #7