### PR TITLE
docs: add installation and MCP client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,32 @@ Route GitHub MCP requests to the right GitHub identity automatically.
 
 It is designed for developers who work across multiple GitHub identities — personal accounts, work accounts, organizations, client accounts, bot accounts, or permission-scoped credentials — but want to expose **one GitHub MCP tool surface** to their AI tools.
 
-> Project status: early development.
-> The v0.1 architecture and roadmap are defined, but the router is not yet ready for production use.
+> Project status: pre-release v0.1 development.
+> The local router, CLI, and stdio MCP path are implemented on `main`, but no
+> crates.io package or downloadable release binary is published yet. Treat the
+> current build as a development release, not a production security boundary.
+
+## Quick start
+
+The supported installation path today is building from this repository. Start
+with the [installation guide](docs/installation.md), then follow the
+[configuration guide](docs/configuration.md) to create two identity-only
+profiles and route repositories to them.
+
+```bash
+cargo build --release
+gh auth status
+gh-mcp-router init --config ~/.config/gh-mcp-router/config.yaml
+gh-mcp-router profiles --config ~/.config/gh-mcp-router/config.yaml
+gh-mcp-router route ExampleOrg/backend --config ~/.config/gh-mcp-router/config.yaml
+gh-mcp-router doctor --config ~/.config/gh-mcp-router/config.yaml
+```
+
+The generated configuration contains account references and routing metadata,
+never tokens. Before connecting a client, read the
+[MCP client integration guide](docs/mcp-client-integration.md). The
+[troubleshooting guide](docs/troubleshooting.md) covers the common setup and
+upstream failures.
 
 ## The problem
 
@@ -92,7 +116,7 @@ should use the appropriate identities automatically.
 
 Routing is based on repository context.
 
-Planned matching levels are:
+Matching levels are:
 
 ```text
 exact repository
@@ -244,7 +268,7 @@ gh-mcp-router
 
 GitHub behavior remains owned by the official GitHub MCP Server.
 
-## Planned v0.1 architecture
+## v0.1 architecture
 
 The initial implementation is being developed in Rust.
 
@@ -263,7 +287,7 @@ src/
 └── security/
 ```
 
-The project will begin as a single crate.
+The project remains a single crate.
 
 It should only be split into multiple crates when real architectural boundaries justify the additional complexity.
 
@@ -326,8 +350,8 @@ discovery, then consumes the client's `initialized` notification. Cancellation,
 shutdown, and exit lifecycle messages are handled without exposing credentials.
 
 The proxy can be used as a library through `McpRouter::handle_message` or its
-newline-delimited `serve_stdio` entry point. The command-line `serve` wiring
-remains part of the later CLI workflow feature.
+newline-delimited `serve_stdio` entry point. The command-line `serve` command
+starts this same client-facing transport.
 
 HTTP upstream routing with request-scoped authorization may be explored later where appropriate, but it is not required for the first implementation.
 
@@ -335,9 +359,9 @@ HTTP upstream routing with request-scoped authorization may be explored later wh
 
 Not every MCP call represents a repository in exactly the same way.
 
-The router will attempt to normalize repository context from the most explicit available source.
+The router normalizes repository context from the most explicit available source.
 
-Planned priority:
+Resolution priority:
 
 ```text
 explicit owner + repo
@@ -373,7 +397,7 @@ ambiguous result.
 
 ## CLI
 
-The v0.1 CLI is expected to provide:
+The v0.1 CLI provides:
 
 ```bash
 gh-mcp-router init
@@ -523,11 +547,13 @@ github-mcp-server executable, credential availability, and upstream process
 startup. Diagnostic failures use non-zero exit codes and never include token
 values.
 
-For an MCP client, configure one stdio server command:
+For an MCP client, configure one stdio server command. The exact client file
+format is documented in [MCP client integration](docs/mcp-client-integration.md):
 
     {
       "mcpServers": {
         "github": {
+          "type": "stdio",
           "command": "gh-mcp-router",
           "args": ["serve", "--config", "/absolute/path/to/config.yaml"]
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ GitHub identities.
 The project does not replace the official server. GitHub capability behavior
 remains upstream, while this project owns the identity-selection boundary.
 
-## Planned flow
+## Implemented v0.1 flow
 
 The v0.1 client transport is JSON-RPC 2.0 over newline-delimited stdio. The
 router forwards the official upstream MCP protocol version and capabilities;
@@ -138,18 +138,18 @@ metadata fields `request_id`, `operation_class`, `repository`, `profile`,
 through token-pattern redaction. Raw MCP payloads, subprocess output,
 authorization headers, and credentials are not logged.
 
-## Planned feature ownership
+## Feature ownership
 
 The next features add behavior behind the boundaries established here:
 
 - configuration parsing and validation (`#3`, implemented)
-- GitHub CLI credential discovery (`#4`)
+- GitHub CLI credential discovery (`#4`, implemented)
 - deterministic routing evaluation (`#5`, implemented)
 - repository context discovery and safe write policy (`#6`, implemented)
 - profile-isolated upstream sessions (`#7`, implemented)
 - MCP request forwarding (`#8`, implemented)
 - complete CLI workflows (`#9`, implemented)
-- deeper secret, concurrency, logging, and process hardening (`#10`)
+- deeper secret, concurrency, logging, and process hardening (`#10`, implemented)
 
 ## CLI boundary
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,183 @@
+# Router configuration
+
+The configuration is YAML by default. A file ending in `.json` is parsed as
+JSON. Unknown fields are rejected, including token-like fields.
+
+Profiles identify accounts; they do not contain credentials. Routes are
+evaluated in this order:
+
+```text
+exact repository > repository glob > owner > host > default
+```
+
+At one specificity, different profiles produce an ambiguous result. A write
+must not fall back to `default_profile` unless
+`ambiguity_policy.write: default_profile` is explicitly configured. The safer
+default is to fail closed.
+
+## Personal and work accounts
+
+This is a complete two-account configuration using synthetic usernames and an
+organization name. Replace the identity references with usernames shown by
+`gh auth status`.
+
+```yaml
+profiles:
+  personal:
+    provider: gh
+    user: personal-user
+    host: github.com
+
+  work:
+    provider: gh
+    user: work-user
+    host: github.com
+
+routes:
+  - match:
+      owner: PersonalUser
+    profile: personal
+
+  - match:
+      owner: ExampleOrg
+    profile: work
+
+default_profile: personal
+
+ambiguity_policy:
+  read: default_profile
+  write: error
+```
+
+Check the result without resolving a credential:
+
+```bash
+gh-mcp-router route ExampleOrg/backend --config config.yaml
+gh-mcp-router explain ExampleOrg/backend --config config.yaml
+```
+
+## Personal account plus organization route
+
+An owner route is enough when all repositories in an organization use the same
+identity:
+
+```yaml
+profiles:
+  personal:
+    provider: gh
+    user: personal-user
+  work:
+    provider: gh
+    user: work-user
+
+routes:
+  - match: { owner: ExampleOrg }
+    profile: work
+  - match: { owner: personal-user }
+    profile: personal
+
+default_profile: personal
+ambiguity_policy: { read: default_profile, write: error }
+```
+
+## Repository-specific override
+
+More specific rules win over an owner rule. This sends one repository back to
+the personal profile while other `ExampleOrg` repositories use `work`:
+
+```yaml
+profiles:
+  personal:
+    provider: gh
+    user: personal-user
+  work:
+    provider: gh
+    user: work-user
+
+routes:
+  - match:
+      repo: ExampleOrg/public-docs
+    profile: personal
+  - match:
+      repo: ExampleOrg/security-*
+    profile: work
+  - match:
+      owner: ExampleOrg
+    profile: work
+
+default_profile: personal
+ambiguity_policy: { read: default_profile, write: error }
+```
+
+`repo` is `OWNER/REPOSITORY`; a single `*` is supported for a repository glob.
+Do not use a route to rewrite the owner, repository, or host supplied by an MCP
+call.
+
+## GitHub Enterprise or another custom host
+
+Custom GitHub hosts are supported as host values without a scheme or path:
+
+```yaml
+profiles:
+  enterprise:
+    provider: gh
+    user: enterprise-user
+    host: github.example.com
+    gh_config_dir: ${HOME}/.config/gh-enterprise
+
+routes:
+  - match:
+      host: github.example.com
+    profile: enterprise
+
+ambiguity_policy:
+  read: error
+  write: error
+```
+
+Authenticate that host with the same `gh` host value and ensure the referenced
+config directory exists. The router passes the host to the selected upstream
+child; it does not silently map a custom host to `github.com`.
+
+## No-default, fail-closed configuration
+
+Omit `default_profile` and make both policies explicit when every request must
+carry enough repository context to select a profile:
+
+```yaml
+profiles:
+  personal: { provider: gh, user: personal-user }
+  work: { provider: gh, user: work-user }
+
+routes:
+  - match: { owner: PersonalUser }
+    profile: personal
+  - match: { owner: ExampleOrg }
+    profile: work
+
+ambiguity_policy:
+  read: error
+  write: error
+```
+
+With this policy, `route`/`explain` report a no-match or ambiguous decision,
+and an MCP write without safe context is rejected rather than guessed.
+
+## Profile-specific `GH_CONFIG_DIR`
+
+Use `gh_config_dir` when two profiles should not share GitHub CLI state:
+
+```yaml
+profiles:
+  personal:
+    provider: gh
+    user: personal-user
+    gh_config_dir: ${HOME}/.config/gh-personal
+  work:
+    provider: gh
+    user: work-user
+    gh_config_dir: ${HOME}/.config/gh-work
+```
+
+The router expands `${HOME}` and `~` at the credential boundary. It never
+persists the resolved credential in this file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,12 @@ evaluated in this order:
 exact repository > repository glob > owner > host > default
 ```
 
-At one specificity, different profiles produce an ambiguous result. A write
-must not fall back to `default_profile` unless
-`ambiguity_policy.write: default_profile` is explicitly configured. The safer
-default is to fail closed.
+At one specificity, different profiles produce an ambiguous result and are
+always rejected. A concrete repository context with no matching route may use
+`default_profile` only when the corresponding policy explicitly allows it. A
+missing repository context is never made safe by that policy: repository-free
+reads may use an explicit default, while writes and unknown operations require
+deterministic context. The safer default is to fail closed.
 
 ## Personal and work accounts
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,7 +90,12 @@ GH_CONFIG_DIR="$HOME/.config/gh-work" gh auth status --hostname github.com
 
 Reference those existing directories with `gh_config_dir` in the profile
 configuration. The directory must exist when `profiles`, `doctor`, or `serve`
-uses that profile.
+uses that profile. This is an alternative to the shared `gh` configuration
+workflow below: the current `init` command discovers accounts from the default
+GitHub CLI configuration and has no option to discover accounts from multiple
+`GH_CONFIG_DIR` values. For this isolated setup, skip `init` and create the
+profiles manually using the examples in
+[`configuration.md`](configuration.md), including each `gh_config_dir`.
 
 `gh-mcp-router` never runs `gh auth switch`. It does not change the parent
 process's active account and it does not require a globally selected account to
@@ -98,7 +103,8 @@ be changed while requests are in flight.
 
 ## Create a starter configuration
 
-Use `init` after authenticating `gh`:
+Use `init` when the accounts are available in the default GitHub CLI
+configuration:
 
 ```bash
 gh-mcp-router init \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,134 @@
+# Installation and GitHub authentication
+
+This document describes the supported pre-release v0.1 installation path.
+
+## Availability
+
+There is currently no published `gh-mcp-router` crate on crates.io and no
+downloadable release binary. `cargo install gh-mcp-router` is therefore not a
+supported command yet. Build from a checked-out repository instead:
+
+```bash
+git clone https://github.com/mors119/gh-mcp-router.git
+cd gh-mcp-router
+cargo build --release
+```
+
+The binary is `target/release/gh-mcp-router`. To install it in a user-level
+directory on Unix-like systems:
+
+```bash
+mkdir -p "$HOME/.local/bin"
+install -m 755 target/release/gh-mcp-router "$HOME/.local/bin/gh-mcp-router"
+```
+
+Ensure `$HOME/.local/bin` is on `PATH`, or use the absolute binary path in the
+MCP client configuration. A local Cargo install is also possible while
+developing from the checkout:
+
+```bash
+cargo install --path .
+```
+
+That command installs the checked-out source; it does not download a release
+from crates.io.
+
+## Prerequisites
+
+The router relies on two external executables:
+
+1. [GitHub CLI (`gh`)](https://cli.github.com/) for account discovery and
+   profile-specific credential lookup.
+2. The official
+   [GitHub MCP Server](https://github.com/github/github-mcp-server) binary,
+   named `github-mcp-server` and available on `PATH`.
+
+The router does not download, replace, or reimplement the upstream GitHub MCP
+Server. Verify the tools before starting a client:
+
+```bash
+gh --version
+github-mcp-server --help
+gh-mcp-router --help
+```
+
+If the upstream binary is outside `PATH`, use an absolute path for diagnostics
+and serving:
+
+```bash
+gh-mcp-router doctor --upstream-binary /absolute/path/to/github-mcp-server
+gh-mcp-router serve --upstream-binary /absolute/path/to/github-mcp-server
+```
+
+The `--upstream-binary` option selects the executable only. It does not change
+the credential or routing configuration.
+
+## Prepare multiple GitHub CLI accounts
+
+Authenticate each account with `gh`, then inspect the accounts known to the
+host:
+
+```bash
+gh auth status --hostname github.com
+```
+
+The output should identify the usernames that will be referenced by the
+router, for example `personal-user` and `work-user`. The router uses the
+non-secret username and host as a lookup reference; it asks `gh` for the
+selected account's credential only after routing has selected a profile.
+
+For accounts that should be isolated completely, create one GitHub CLI config
+directory per account and authenticate within that directory:
+
+```bash
+mkdir -p "$HOME/.config/gh-personal" "$HOME/.config/gh-work"
+GH_CONFIG_DIR="$HOME/.config/gh-personal" gh auth login --hostname github.com
+GH_CONFIG_DIR="$HOME/.config/gh-work" gh auth login --hostname github.com
+GH_CONFIG_DIR="$HOME/.config/gh-personal" gh auth status --hostname github.com
+GH_CONFIG_DIR="$HOME/.config/gh-work" gh auth status --hostname github.com
+```
+
+Reference those existing directories with `gh_config_dir` in the profile
+configuration. The directory must exist when `profiles`, `doctor`, or `serve`
+uses that profile.
+
+`gh-mcp-router` never runs `gh auth switch`. It does not change the parent
+process's active account and it does not require a globally selected account to
+be changed while requests are in flight.
+
+## Create a starter configuration
+
+Use `init` after authenticating `gh`:
+
+```bash
+gh-mcp-router init \
+  --config "$HOME/.config/gh-mcp-router/config.yaml" \
+  --profile personal-user=personal \
+  --profile work-user=work
+```
+
+`init` discovers authenticated accounts and writes only profile references. It
+does not write tokens. It refuses to overwrite an existing configuration;
+pass `--force` only when replacing it is intentional. Add routes to the
+generated file, then validate and inspect it:
+
+```bash
+gh-mcp-router validate --config "$HOME/.config/gh-mcp-router/config.yaml"
+gh-mcp-router profiles --config "$HOME/.config/gh-mcp-router/config.yaml"
+gh-mcp-router doctor --config "$HOME/.config/gh-mcp-router/config.yaml"
+```
+
+The default path is `$XDG_CONFIG_HOME/gh-mcp-router/config.yaml` when
+`XDG_CONFIG_HOME` is set, otherwise `~/.config/gh-mcp-router/config.yaml` on
+Unix-like systems. Windows uses `%APPDATA%/gh-mcp-router/config.yaml`.
+Use `--config PATH` when the file is elsewhere.
+
+## Security expectations
+
+Router configuration contains usernames, hosts, route rules, and optional
+`GH_CONFIG_DIR` references. It must not contain a PAT, OAuth token, GitHub App
+private key, or an `Authorization` header. The resolved credential is passed
+only to the selected official GitHub MCP child process through its environment.
+
+For the trust model, best-effort in-memory protections, process boundaries,
+and logging policy, see [Security and trust](security.md).

--- a/docs/mcp-client-integration.md
+++ b/docs/mcp-client-integration.md
@@ -1,0 +1,121 @@
+# MCP client integration
+
+The v0.1 client-facing transport is local stdio. The client starts one
+`gh-mcp-router serve` process and exchanges newline-delimited JSON-RPC 2.0
+messages with it. The router performs profile selection behind that one
+connection and exposes one upstream GitHub tool surface.
+
+Do not configure one server per GitHub account. That would expose duplicated
+account-specific tools and bypass the router's request routing.
+
+## VS Code
+
+VS Code uses a `servers` object in `.vscode/mcp.json`. Add one server entry and
+use absolute paths for both the binary and configuration file when the client
+will start from an unexpected working directory:
+
+```json
+{
+  "servers": {
+    "github-router": {
+      "type": "stdio",
+      "command": "/absolute/path/to/gh-mcp-router",
+      "args": [
+        "serve",
+        "--config",
+        "/absolute/path/to/gh-mcp-router.yaml"
+      ]
+    }
+  }
+}
+```
+
+The same entry can be added to the VS Code user profile with its command-line
+helper:
+
+```bash
+code --add-mcp '{"name":"github-router","type":"stdio","command":"/absolute/path/to/gh-mcp-router","args":["serve","--config","/absolute/path/to/gh-mcp-router.yaml"]}'
+```
+
+In VS Code, run `MCP: List Servers`, start `github-router`, and approve the
+server trust prompt if shown. Use `Configure Tools` in Chat to confirm that the
+server presents one GitHub tool list. If the server was previously configured
+under another command or name, stop/remove the stale entry before comparing
+tool lists.
+
+VS Code's configuration format and lifecycle are documented in the
+[VS Code MCP configuration reference](https://code.visualstudio.com/docs/agents/reference/mcp-configuration).
+
+## MCP Inspector CLI verification
+
+The MCP Inspector CLI is a scriptable stdio MCP client. It is the reproducible
+client used to verify the router's documented handshake and tool discovery
+path:
+
+```bash
+npx @modelcontextprotocol/inspector --cli \
+  /absolute/path/to/gh-mcp-router serve \
+  --method tools/list \
+  --format json
+```
+
+This ad-hoc form uses the router's default configuration path. The positional
+arguments after `--cli` are the command and arguments for the stdio server. For
+a non-default router config path, put the complete launch command in an
+Inspector config file as shown below; this avoids the Inspector's own
+`--config` option being confused with the router's `--config` option.
+
+For a reusable Inspector configuration file, use its `mcpServers` format:
+
+```json
+{
+  "mcpServers": {
+    "github-router": {
+      "type": "stdio",
+      "command": "/absolute/path/to/gh-mcp-router",
+      "args": [
+        "serve",
+        "--config",
+        "/absolute/path/to/gh-mcp-router.yaml"
+      ]
+    }
+  }
+}
+```
+
+Then query the configured server:
+
+```bash
+npx @modelcontextprotocol/inspector --cli \
+  --config /absolute/path/to/mcp.json \
+  --server github-router \
+  --method initialize \
+  --format json
+
+npx @modelcontextprotocol/inspector --cli \
+  --config /absolute/path/to/mcp.json \
+  --server github-router \
+  --method tools/list \
+  --format json
+```
+
+The repository's validation uses the ad-hoc form so the client command is
+visible in the test output. The Inspector is a development verification tool;
+it does not add a runtime dependency to `gh-mcp-router`.
+
+## Other clients and unsupported claims
+
+Any MCP host that can launch local stdio servers may be able to use the same
+command, but configuration keys and lifecycle behavior vary by host. Claude
+Desktop, Claude Code, Cursor, ChatGPT, and other clients are not claimed as
+verified v0.1 integrations by this repository unless a client-specific setup
+has been exercised and added here. In particular, this project does not claim
+ChatGPT local MCP support.
+
+## Client-side safety notes
+
+Do not add `GITHUB_PERSONAL_ACCESS_TOKEN`, `GH_TOKEN`, or an `Authorization`
+header to the client configuration. Authentication is resolved by the router
+from the configured `gh` profile. Client logs and MCP error panes should still
+be treated as local diagnostic output; use `doctor` and the security guidance
+when investigating failures.

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,8 +27,12 @@ one profile and cannot be reused for another profile. Profile-specific host and
 
 Repository context and routing are request-scoped. The router prefers explicit
 owner/repository arguments, then other documented repository sources. A missing
-or ambiguous context is not silently repaired. Writes fail closed unless the
-configured policy explicitly permits a default profile.
+or ambiguous context is not silently repaired, and writes with either condition
+always fail closed. For a known operation with a concrete repository context
+that has no matching route, the configured policy may explicitly permit a
+default profile. Ambiguous matching routes are never resolved by that policy;
+repository-free reads may use an explicit default, while repository-free writes
+and unknown operations require deterministic context.
 
 Use these commands before enabling a client:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,53 @@
+# Security and trust model
+
+The v0.1 router is a local developer process. The local user and configured MCP
+client are trusted; the router is not a public multi-tenant credential broker.
+
+## Credential flow
+
+```text
+profile reference in config
+        ↓
+gh auth status / gh auth token for that profile
+        ↓
+selected profile's official github-mcp-server child
+```
+
+Configuration stores provider, username, host, route rules, and optional
+`GH_CONFIG_DIR` references. It never stores raw PATs, OAuth tokens, GitHub App
+private keys, or authorization headers. The parent process is not changed and
+the router never calls `gh auth switch`.
+
+Each upstream child receives only its selected profile's credential through
+`GITHUB_PERSONAL_ACCESS_TOKEN`. A child session is permanently associated with
+one profile and cannot be reused for another profile. Profile-specific host and
+`GH_CONFIG_DIR` values are also scoped to that child.
+
+## Routing and writes
+
+Repository context and routing are request-scoped. The router prefers explicit
+owner/repository arguments, then other documented repository sources. A missing
+or ambiguous context is not silently repaired. Writes fail closed unless the
+configured policy explicitly permits a default profile.
+
+Use these commands before enabling a client:
+
+```bash
+gh-mcp-router route OWNER/REPO --config config.yaml
+gh-mcp-router explain OWNER/REPO --config config.yaml
+gh-mcp-router doctor --config config.yaml --json
+```
+
+## Best-effort secret lifetime
+
+Secret values use a redacting wrapper and zeroize owned buffers when their last
+reference is dropped. Rust and the operating system can still make unavoidable
+copies during allocation, subprocess creation, paging, or crash handling. v0.1
+therefore provides best-effort in-memory protection, not an instant-erasure
+guarantee.
+
+Logs and diagnostics contain routing metadata such as profile, repository,
+operation class, and session status. They must not contain credentials,
+authorization headers, raw credential-provider output, or unredacted upstream
+errors. Set `GH_MCP_ROUTER_LOG_LEVEL` to `error`, `warn`, `info`, `debug`, or
+`trace`; increasing verbosity changes metadata volume only.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,106 @@
+# Troubleshooting
+
+Run diagnostics with the same configuration and environment that the MCP
+client will use:
+
+```bash
+gh-mcp-router profiles --config /absolute/path/to/config.yaml
+gh-mcp-router explain ExampleOrg/backend --config /absolute/path/to/config.yaml
+gh-mcp-router doctor --config /absolute/path/to/config.yaml --json
+```
+
+## `gh` is not found
+
+Install the GitHub CLI and make sure it is on the `PATH` inherited by the
+client. Verify with:
+
+```bash
+command -v gh
+gh --version
+```
+
+GUI-launched clients can have a different `PATH` from a terminal. Use absolute
+paths for the router and upstream binary, or launch the client from an
+environment with the required `PATH`.
+
+## A GitHub account is missing
+
+Check the host and username in the profile:
+
+```bash
+gh auth status --hostname github.com
+gh-mcp-router profiles --config config.yaml
+```
+
+For an isolated profile, repeat the check with its configured directory:
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-work" gh auth status --hostname github.com
+```
+
+The profile's `user` and `host` must match an authenticated account. The router
+does not switch accounts to make a mismatch pass.
+
+## The upstream GitHub MCP Server is not found
+
+Install the official `github-mcp-server` binary and check it directly:
+
+```bash
+command -v github-mcp-server
+github-mcp-server --help
+```
+
+If it is not on `PATH`, pass its absolute path to both `doctor` and `serve`:
+
+```bash
+gh-mcp-router doctor --upstream-binary /absolute/path/to/github-mcp-server --config config.yaml
+gh-mcp-router serve --upstream-binary /absolute/path/to/github-mcp-server --config config.yaml
+```
+
+## No matching route or an ambiguous route
+
+Inspect the normalized context and rule evaluation:
+
+```bash
+gh-mcp-router explain OWNER/REPO --config config.yaml
+```
+
+Add an exact `repo` rule for an override, or remove conflicting rules at the
+same specificity. A write with missing or ambiguous repository context is
+expected to fail closed.
+
+## The selected identity lacks permission
+
+Routing can select only an identity; GitHub still enforces that account's
+repository permissions. Confirm the selected username with `profiles` and test
+the account's access through its own `gh_config_dir` if configured. Add a route
+to an account that has the required permission; do not broaden credentials in
+router configuration.
+
+## The upstream process exits
+
+Run `doctor` with the same `--upstream-binary` and configuration. Confirm the
+upstream executable accepts the default `stdio` startup argument and that the
+selected `gh` account is authenticated. A failed session is discarded and is
+restarted on the next routed request; one profile's failure must not reassign
+another profile's session.
+
+## The client shows stale or duplicate GitHub tools
+
+Keep only one router entry for this project. Remove or disable older direct
+`github-mcp-server` entries and account-specific router entries, restart the
+client, and run its MCP server list/refresh command. The router itself exposes
+one validated upstream tool surface; it does not create per-account tool names.
+
+## Configuration errors
+
+Validate the exact file passed to the client:
+
+```bash
+gh-mcp-router validate --config /absolute/path/to/config.yaml
+```
+
+Use YAML or JSON matching the checked-in
+[`examples/config.example.yaml`](../examples/config.example.yaml). Never add a
+token field to silence a validation error; credentials are intentionally
+resolved through `gh`.


### PR DESCRIPTION
## Summary

- Add a source-install and GitHub CLI authentication guide for pre-release v0.1.
- Add complete routing configuration examples, including enterprise and fail-closed setups.
- Add VS Code and MCP Inspector stdio integration instructions plus troubleshooting and security guidance.

## Implementation

Documentation is split by task: installation/authentication, configuration, MCP client integration, security/trust, and troubleshooting. README and architecture wording now distinguish implemented behavior from future or unsupported behavior. The docs use identity references only and keep the official GitHub MCP Server as the upstream capability provider.

## Security / routing impact

- Documents that router configuration never contains PATs, OAuth tokens, or authorization headers.
- Documents profile-specific `GH_CONFIG_DIR`, no global `gh auth switch`, child-process credential isolation, deterministic routing, and fail-closed writes.
- No runtime security or routing code was changed.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] `cargo build --release` and `validate`/`route`/`explain` against the checked-in example configuration
- [x] Clean temporary HOME with synthetic `gh`: documented `init`, `profiles`, and `validate` workflow
- [x] VS Code 1.134 `code --add-mcp` accepted the documented `servers`/`type: "stdio"` entry in an isolated user profile
- [x] MCP Inspector CLI completed `initialize` and `tools/list` through `gh-mcp-router serve` with synthetic two-profile `gh` and upstream processes
- [x] Diff scan found no credential-shaped values, `.env` files, build outputs, or unrelated files

## Out of scope

- crates.io publication and downloadable release binaries (Issue #13)
- full multi-profile integration matrix (Issue #12)
- unverified client-specific setups, including ChatGPT local MCP support

Closes #11