### PR TITLE
ci: add verification and release workflow

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,13 @@
+This release contains the local-first router and its profile-isolated stdio
+integration with the official GitHub MCP Server.
+
+Security and compatibility limitations:
+
+- The router is a local developer process, not a public multi-tenant secret
+  broker.
+- Credentials remain in the user's GitHub CLI authentication context and are
+  passed only to the selected upstream child process.
+- The compatibility baseline is `github-mcp-server` v1.11.0. Newer upstream
+  versions should be validated before use if their MCP surface changes.
+- v0.1 release artifacts support Linux x86_64 and macOS x86_64/arm64. Windows
+  is not a supported platform in this release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
   audit:
     name: Dependency advisory audit
     runs-on: ubuntu-latest
+    # audit-check publishes a richer commit check when this permission is
+    # available. Fork pull requests receive a read-only token from GitHub; the
+    # action falls back to the job log for those events.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,16 @@ on:
 permissions:
   contents: read
 
+env:
+  # The compatibility smoke is intentionally pinned so an upstream change is
+  # reviewed and reproduced instead of silently changing CI behavior.
+  GITHUB_MCP_SERVER_VERSION: v1.11.0
+  GITHUB_MCP_SERVER_ASSET: github-mcp-server_Linux_x86_64.tar.gz
+  GITHUB_MCP_SERVER_SHA256: 3b73bb7be0c8b043f861e90410df8ebdfc71b83128c54ced75fb32c4ff697fc5
+
 jobs:
-  check:
-    name: Check
+  verify:
+    name: Verify Rust project
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -24,8 +31,76 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Check compilation
-        run: cargo check --locked
+      - name: Run clippy
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Run complete test suite
+        run: cargo test --locked --all-features
+
+      - name: Run fake multi-profile integration matrix
+        run: cargo test --locked --all-features --test multi_profile_integration
+
+      - name: Verify debug build
+        run: cargo build --locked --all-features
+
+      - name: Verify package archive
+        run: cargo package --locked
+
+  platform:
+    name: Build and test ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: Linux x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - platform: macOS x86_64
+            os: macos-15-intel
+            target: x86_64-apple-darwin
+          - platform: macOS arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
 
       - name: Run tests
-        run: cargo test --locked
+        run: cargo test --locked --all-features --target ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+  audit:
+    name: Dependency advisory audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Audit Rust dependencies
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upstream-compatibility:
+    name: Check official upstream compatibility baseline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download pinned upstream release
+        run: curl --fail --location --remote-name "https://github.com/github/github-mcp-server/releases/download/${GITHUB_MCP_SERVER_VERSION}/${GITHUB_MCP_SERVER_ASSET}"
+
+      - name: Verify upstream checksum
+        run: echo "${GITHUB_MCP_SERVER_SHA256}  ${GITHUB_MCP_SERVER_ASSET}" | sha256sum --check
+
+      - name: Smoke test upstream executable
+        run: |
+          tar --extract --gzip --file "${GITHUB_MCP_SERVER_ASSET}"
+          test -x github-mcp-server
+          ./github-mcp-server --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check tag matches package version
+        run: test "${GITHUB_REF_NAME}" = "v$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --locked --all-features
+
+      - name: Verify package archive
+        run: cargo package --locked
+
+  build:
+    name: Package ${{ matrix.platform }}
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: gh-mcp-router-linux-x86_64.tar.gz
+          - platform: macos-x86_64
+            os: macos-15-intel
+            target: x86_64-apple-darwin
+            archive: gh-mcp-router-macos-x86_64.tar.gz
+          - platform: macos-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+            archive: gh-mcp-router-macos-arm64.tar.gz
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Create checksummed archive
+        run: |
+          mkdir dist
+          tar --create --gzip --file "dist/${{ matrix.archive }}" \
+            --directory "target/${{ matrix.target }}/release" gh-mcp-router
+          (cd dist && shasum -a 256 "${{ matrix.archive }}" > "${{ matrix.archive }}.sha256")
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release metadata
+        uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Verify artifact checksums
+        working-directory: dist
+        run: sha256sum --check -- *.sha256
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}" dist/*
+          --repo "${GITHUB_REPOSITORY}"
+          --verify-tag
+          --title "gh-mcp-router ${GITHUB_REF_NAME}"
+          --generate-notes
+          --notes-file .github/release-notes.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,12 @@ name = "gh-mcp-router"
 version = "0.1.0"
 edition = "2021"
 description = "A local-first identity and routing layer for the official GitHub MCP Server"
-license = "MIT"
+license = "Apache-2.0"
+repository = "https://github.com/mors119/gh-mcp-router"
+readme = "README.md"
+keywords = ["github", "mcp", "routing", "multi-account"]
+categories = ["command-line-utilities"]
+exclude = [".github/", "AGENTS.md", ".gitignore"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ Route GitHub MCP requests to the right GitHub identity automatically.
 It is designed for developers who work across multiple GitHub identities — personal accounts, work accounts, organizations, client accounts, bot accounts, or permission-scoped credentials — but want to expose **one GitHub MCP tool surface** to their AI tools.
 
 > Project status: pre-release v0.1 development.
-> The local router, CLI, and stdio MCP path are implemented on `main`, but no
-> crates.io package or downloadable release binary is published yet. Treat the
-> current build as a development release, not a production security boundary.
+> The local router, CLI, and stdio MCP path are implemented on `main`. Tagged
+> releases build checksummed binaries for the supported platforms, but v0.1.0
+> remains gated on final validation in Issue #14. Treat pre-release builds as a
+> development release, not a production security boundary.
 
 ## Quick start
 
-The supported installation path today is building from this repository. Start
-with the [installation guide](docs/installation.md), then follow the
+The supported installation paths are a checksummed GitHub Release binary or a
+build from this repository. Start with the [installation guide](docs/installation.md), then follow the
 [configuration guide](docs/configuration.md) to create two identity-only
 profiles and route repositories to them.
 
@@ -36,6 +37,10 @@ upstream failures.
 Credential-free unit and multi-profile integration tests are documented in
 [`docs/testing.md`](docs/testing.md). Live GitHub testing is opt-in and
 non-destructive.
+
+See [compatibility and supported platforms](docs/compatibility.md) for the
+tested official GitHub MCP Server baseline and [the release process](docs/releasing.md)
+for the tag-driven artifact workflow.
 
 ## The problem
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,44 @@
+# Compatibility and supported platforms
+
+## Router and Rust
+
+The package version is the semantic version shown by:
+
+```bash
+gh-mcp-router --version
+```
+
+The repository does not currently declare an MSRV. CI uses the stable Rust
+toolchain and `Cargo.lock` is checked with `--locked` for reproducible
+dependency resolution.
+
+## Official GitHub MCP Server
+
+The CI and release workflows use `github-mcp-server` **v1.11.0** as the
+compatibility baseline. CI downloads that exact Linux x86_64 release, verifies
+the upstream-provided SHA-256 checksum, and runs its executable smoke check.
+The credential-free fake-upstream integration matrix covers the MCP initialize,
+tool discovery, forwarding, routing, concurrency, error, and shutdown paths.
+
+This is a reproducible baseline, not a claim that every future upstream
+release is compatible. When updating the baseline, change the version, asset,
+and checksum together in `.github/workflows/ci.yml`, rerun the full suite, and
+review upstream MCP protocol/tool-surface changes before updating this page.
+
+The router uses the upstream MCP protocol and tool surface; it does not copy
+GitHub capability definitions into this repository.
+
+## Supported release platforms
+
+Release artifacts are built and tested on:
+
+| Platform | Rust target | Artifact |
+| --- | --- | --- |
+| Linux x86_64 (glibc) | `x86_64-unknown-linux-gnu` | `gh-mcp-router-linux-x86_64.tar.gz` |
+| macOS x86_64 | `x86_64-apple-darwin` | `gh-mcp-router-macos-x86_64.tar.gz` |
+| macOS arm64 | `aarch64-apple-darwin` | `gh-mcp-router-macos-arm64.tar.gz` |
+
+Windows is not claimed as supported by v0.1 because its process and stdio
+behavior has not been included in the tested release matrix. Other targets
+may compile from source but are not release-supported unless added to both the
+CI and release matrices.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,12 +1,25 @@
 # Installation and GitHub authentication
 
-This document describes the supported pre-release v0.1 installation path.
+This document describes the supported v0.1 installation paths.
 
 ## Availability
 
-There is currently no published `gh-mcp-router` crate on crates.io and no
-downloadable release binary. `cargo install gh-mcp-router` is therefore not a
-supported command yet. Build from a checked-out repository instead:
+The project is distributed as checksummed binaries from tagged GitHub Releases;
+`cargo install gh-mcp-router` from crates.io is not supported yet. Download the
+archive matching your platform from the release page, verify its sidecar
+checksum, and install the binary:
+
+```bash
+sha256sum --check gh-mcp-router-linux-x86_64.tar.gz.sha256
+tar -xzf gh-mcp-router-linux-x86_64.tar.gz
+install -m 755 gh-mcp-router "$HOME/.local/bin/gh-mcp-router"
+```
+
+On macOS, use `shasum -a 256 --check` and the x86_64 or arm64 archive matching
+the machine. See [compatibility.md](compatibility.md) for the complete support
+matrix.
+
+For development or unsupported targets, build from a checked-out repository:
 
 ```bash
 git clone https://github.com/mors119/gh-mcp-router.git

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,58 @@
+# Release process
+
+Releases use semantic-version tags and are created by GitHub Actions. The
+workflow does not publish to crates.io and does not run on ordinary pushes.
+
+Before creating `v0.1.0`, the v0.1 roadmap Features must be complete and
+Issue #14 must pass. The release notes must retain the security and upstream
+compatibility limitations described in `.github/release-notes.md`.
+
+## Release candidate checklist
+
+1. Confirm the release candidate is on `main` and that the required roadmap
+   Issues, including #10 and #12, are merged.
+2. Run the complete local checks:
+
+   ```bash
+   cargo fmt --check
+   cargo clippy --all-targets --all-features -- -D warnings
+   cargo test --all-features
+   cargo build
+   cargo package --locked
+   ```
+
+3. Verify the executable version:
+
+   ```bash
+   cargo run -- --version
+   ```
+
+4. Update `version` in `Cargo.toml` and `Cargo.lock` as one change when
+   making a later release. The tag must match the package version exactly;
+   the release workflow rejects mismatches.
+5. Create and push an annotated tag without force-pushing:
+
+   ```bash
+   git tag -a v0.1.0 -m "gh-mcp-router v0.1.0"
+   git push origin v0.1.0
+   ```
+
+The tag workflow reruns the release gates, builds the three supported platform
+archives, writes a SHA-256 sidecar for each archive, verifies those checksums,
+and creates a GitHub Release with generated notes plus the repository's
+security/compatibility limitations.
+
+## Installing a release artifact
+
+Download the archive and its matching `.sha256` file from the GitHub Release,
+verify the checksum, then place the `gh-mcp-router` binary on `PATH`:
+
+```bash
+sha256sum --check gh-mcp-router-linux-x86_64.tar.gz.sha256
+tar -xzf gh-mcp-router-linux-x86_64.tar.gz
+install -m 755 gh-mcp-router "$HOME/.local/bin/gh-mcp-router"
+```
+
+On macOS, use `shasum -a 256 --check` and the archive matching the Mac's CPU.
+The source checkout path in [installation.md](installation.md) remains
+available for development and for targets not covered by the release matrix.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -102,6 +102,13 @@ where
     W: Write,
 {
     let parsed = CliArgs::parse(args)?;
+    if parsed.version {
+        write_text(
+            output,
+            concat!("gh-mcp-router ", env!("CARGO_PKG_VERSION"), "\n"),
+        )?;
+        return Ok(());
+    }
     if parsed.help {
         write_text(output, usage())?;
         return Ok(());
@@ -939,7 +946,7 @@ fn format_explanation(report: &ExplanationReport) -> String {
 }
 
 fn usage() -> &'static str {
-    "gh-mcp-router — route GitHub MCP requests by profile\n\nUsage:\n  gh-mcp-router init [--config PATH] [--profile USER=NAME] [--force]\n  gh-mcp-router profiles [--config PATH] [--json]\n  gh-mcp-router route OWNER/REPO [--config PATH] [--json]\n  gh-mcp-router explain OWNER/REPO [--config PATH] [--json]\n  gh-mcp-router doctor [--config PATH] [--json] [--upstream-binary PATH]\n  gh-mcp-router serve [--config PATH] [--upstream-binary PATH]\n\ninit creates identity-only configuration; it never stores credentials.\n"
+    "gh-mcp-router — route GitHub MCP requests by profile\n\nUsage:\n  gh-mcp-router --version\n  gh-mcp-router init [--config PATH] [--profile USER=NAME] [--force]\n  gh-mcp-router profiles [--config PATH] [--json]\n  gh-mcp-router route OWNER/REPO [--config PATH] [--json]\n  gh-mcp-router explain OWNER/REPO [--config PATH] [--json]\n  gh-mcp-router doctor [--config PATH] [--json] [--upstream-binary PATH]\n  gh-mcp-router serve [--config PATH] [--upstream-binary PATH]\n\ninit creates identity-only configuration; it never stores credentials.\n"
 }
 
 #[derive(Debug)]
@@ -950,6 +957,7 @@ struct CliArgs {
     json: bool,
     force: bool,
     help: bool,
+    version: bool,
     host: Option<String>,
     upstream_binary: Option<PathBuf>,
     profile_assignments: Vec<(String, String)>,
@@ -967,6 +975,7 @@ impl CliArgs {
         let mut json = false;
         let mut force = false;
         let mut help = false;
+        let mut version = false;
         let mut host = None;
         let mut upstream_binary = None;
         let mut profile_assignments = Vec::new();
@@ -974,6 +983,7 @@ impl CliArgs {
         while let Some(argument) = arguments.next() {
             match argument.as_str() {
                 "--help" | "-h" => help = true,
+                "--version" | "-V" => version = true,
                 "--json" => json = true,
                 "--force" => force = true,
                 "--config" => config = Some(PathBuf::from(next_value(&mut arguments, "--config")?)),
@@ -1020,6 +1030,7 @@ impl CliArgs {
                 json,
                 force,
                 help: true,
+                version,
                 host,
                 upstream_binary,
                 profile_assignments,
@@ -1041,6 +1052,7 @@ impl CliArgs {
             json,
             force,
             help,
+            version,
             host,
             upstream_binary,
             profile_assignments,
@@ -1319,6 +1331,22 @@ mod tests {
         assert!(args.json);
         assert_eq!(args.command, "route");
         assert_eq!(args.repository.as_deref(), Some("ExampleOrg/repo"));
+    }
+
+    #[test]
+    fn version_output_uses_package_version_without_loading_configuration() {
+        let mut output = Vec::new();
+        try_run_with_writer(
+            ["--version"],
+            credentials(),
+            FakeLauncher::default(),
+            &mut output,
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            format!("gh-mcp-router {}\n", env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Expand pull request and `main` CI to cover formatting, clippy, tests, fake multi-profile integration, builds, package verification, and dependency advisories.
- Test the supported Linux x86_64 and macOS x86_64/arm64 build matrix.
- Add tag-driven checksummed release archives and document installation, compatibility, and the v0.1.0 release path.
- Add user-visible `--version` output and complete Cargo package metadata.

## Implementation

The existing CI workflow is the non-secret verification gate. A separate tag-triggered workflow verifies that the semantic-version tag matches `Cargo.toml`, reruns release gates, builds one archive per supported target, creates SHA-256 sidecars, verifies them, and publishes a GitHub Release. The binary release path is intentionally selected; crates.io publishing is not enabled.

The official `github-mcp-server` v1.11.0 Linux x86_64 release is pinned as the compatibility baseline, with its upstream checksum verified in CI. The supported platform matrix is documented and deliberately excludes Windows until its process/stdio behavior is tested.

## Security / routing impact

- No personal or work GitHub credentials are required by CI.
- Package metadata and release notes preserve the existing local-first, profile-isolated credential model.
- CI uses only the repository-provided `GITHUB_TOKEN` for advisory reporting and tagged release publication.
- Release notes call out the local trust model, upstream compatibility baseline, and unsupported Windows status.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build`

Additional validation:

- [x] `cargo package --locked --allow-dirty` and package archive verification
- [x] `cargo audit`
- [x] Fake multi-profile integration matrix: 5 tests passed
- [x] `gh-mcp-router --version` reports the package version without configuration
- [x] Local Linux release archive and SHA-256 sidecar smoke test
- [x] Official `github-mcp-server` v1.11.0 archive checksum verification
- [x] Workflow YAML parsing and staged diff secret scan

## Out of scope

- Publishing to crates.io.
- Windows release artifacts before process/stdio validation.
- Publishing an actual v0.1.0 release before final validation Issue #14 passes.
- Changes to routing, credentials, upstream MCP behavior, or the multi-profile integration implementation.

Closes #13
