### PR TITLE
chore: add open source project governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all project files.
+* @mors119

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a reproducible problem with gh-mcp-router.
+title: "[BUG] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first. Do not include tokens, authorization headers, private keys, or unredacted command output.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues.
+          required: true
+        - label: I removed secrets and private data from this report.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect to happen?
+      placeholder: Describe the observed and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest safe set of steps, commands, or configuration needed to reproduce it.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Router version
+      placeholder: "v0.1.0 or commit SHA"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "macOS 15 arm64, GitHub CLI version, MCP client"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: Paste redacted output only. Never include credentials or authorization headers.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/mors119/gh-mcp-router/security/advisories/new
+    about: Report credential, authentication, or other security issues privately.
+  - name: Documentation and troubleshooting
+    url: https://github.com/mors119/gh-mcp-router/blob/main/SUPPORT.md
+    about: Check the support guide and troubleshooting documentation first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a focused improvement to gh-mcp-router.
+title: "[FEATURE] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Features should preserve deterministic routing, credential isolation, and the boundary with the official GitHub MCP Server.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and the roadmap.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the smallest behavior or interface that would address the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds or alternative designs did you consider?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why? Link the related issue when one exists. -->
+
+## Validation
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --all-features`
+- [ ] `cargo build`
+
+## Review checklist
+
+- [ ] The change is focused and does not duplicate official GitHub MCP behavior.
+- [ ] Tests and documentation were added or updated where behavior changed.
+- [ ] No credentials, private configuration, or generated build artifacts are included.
+- [ ] Routing remains deterministic and unsafe writes fail closed.
+- [ ] Security, compatibility, and migration impact are called out above if applicable.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `gh-mcp-router` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Open-source contribution, conduct, security, and support guidance.
+- GitHub issue and pull request templates.
+- Dependabot updates and pull-request dependency review.
+
+[Unreleased]: https://github.com/mors119/gh-mcp-router/compare/main...HEAD

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socioeconomic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contribute to a positive environment include:
+
+- demonstrating empathy and kindness toward other people;
+- respecting differing opinions, viewpoints, and experiences;
+- giving and accepting constructive feedback; and
+- taking responsibility and apologizing to those affected by mistakes.
+
+Unacceptable behavior includes harassment, discrimination, personal attacks,
+public or private intimidation, unwelcome sexual attention, publishing private
+information without permission, and other conduct that would reasonably be
+considered inappropriate in a professional community.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these
+standards. They may remove, edit, or reject comments, commits, code, issues,
+and other contributions that violate this Code of Conduct, and may temporarily
+or permanently restrict participation for behavior they consider inappropriate,
+threatening, offensive, or harmful.
+
+## Reporting
+
+Please report unacceptable behavior privately to the repository maintainer
+through GitHub rather than posting it publicly in an issue. Reports will be
+reviewed and handled as confidentially as practical.
+
+## Scope
+
+This Code of Conduct applies within project spaces and whenever an individual
+is officially representing the project in public spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to gh-mcp-router
+
+Thank you for helping improve `gh-mcp-router`. The project is an Apache-2.0
+licensed local routing layer for the official GitHub MCP Server.
+
+## Before you start
+
+For a planned feature or behavior change, check the [open issues](https://github.com/mors119/gh-mcp-router/issues)
+and the v0.1 roadmap. Please open an issue first for changes that affect the
+architecture, routing policy, credential handling, or supported platforms.
+
+Keep contributions focused on:
+
+- repository context detection and deterministic profile selection;
+- credential isolation and safe diagnostics;
+- profile-isolated official GitHub MCP sessions; and
+- MCP forwarding and CLI behavior around those boundaries.
+
+The project does not reimplement GitHub APIs or the official GitHub MCP
+Server's tools.
+
+## Development setup
+
+Install the stable Rust toolchain. The normal test suite does not require real
+GitHub credentials, `gh` authentication, or network access:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo build
+```
+
+The live multi-profile test is opt-in and documented in
+[`docs/testing.md`](docs/testing.md). Never put real tokens in configuration,
+fixtures, logs, or pull requests.
+
+## Pull requests
+
+Create a focused branch from `main`. Explain the user-visible behavior and
+include tests and documentation when behavior changes. Before requesting
+review, confirm that the local validation commands above pass and that no
+credentials or generated build artifacts are included.
+
+Changes that touch routing, context, credentials, upstream sessions, MCP
+forwarding, or security should preserve the module boundaries described in
+[`docs/architecture.md`](docs/architecture.md). In particular:
+
+- routing decisions must be deterministic and explainable;
+- unsafe writes must fail closed;
+- credentials must remain profile-scoped and redacted from diagnostics; and
+- concurrent profiles must not share mutable account or token state.
+
+Use the pull request template to call out security or compatibility impact.
+Maintainers may ask for an issue or design discussion before larger changes.
+
+## Commit and review expectations
+
+Use a concise imperative commit subject, optionally prefixed by the affected
+area (for example, `docs: clarify release support`). Keep unrelated cleanup in
+a separate change. Reviews prioritize correctness, credential safety,
+backward compatibility, and tests over style preferences.
+
+By submitting a contribution, you agree that it is provided under the
+Apache License 2.0, as described in [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -761,19 +761,15 @@ Model Context Protocol:
 
 https://modelcontextprotocol.io/
 
-## Contributing
+## Contributing and project policies
 
-The project is currently in its initial implementation phase.
+Contributions, bug reports, and security reports are welcome. Start with
+[`CONTRIBUTING.md`](CONTRIBUTING.md), [`SUPPORT.md`](SUPPORT.md), and the
+[open issues](https://github.com/mors119/gh-mcp-router/issues). Please use the
+private process in [`SECURITY.md`](SECURITY.md) for vulnerabilities; never put
+credentials or authorization headers in a public issue or pull request.
 
-Before implementing a feature, check the v0.1 Epic and the Feature issue that owns the behavior.
-
-Changes should:
-
-- keep the router focused on identity and request routing,
-- avoid duplicating official GitHub MCP functionality,
-- preserve deterministic routing,
-- keep credentials out of persistent configuration,
-- add tests for changed behavior,
-- and avoid unrelated architectural expansion.
-
-Early feedback on multi-account workflows, organization routing, credential isolation, and MCP client compatibility is welcome.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md) and is
+licensed under the [Apache License 2.0](LICENSE). See [`CHANGELOG.md`](CHANGELOG.md)
+for notable changes and [`docs/releasing.md`](docs/releasing.md) for the
+maintainer release process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security policy
+
+`gh-mcp-router` handles credentials for multiple GitHub identities. Please
+treat suspected credential exposure or identity cross-talk as a security issue,
+not as a normal bug report.
+
+## Supported versions
+
+Security fixes are developed against `main` and the latest published release.
+Pre-release builds are for development and are not a production security
+boundary. See [`docs/compatibility.md`](docs/compatibility.md) for the current
+support and upstream compatibility baseline.
+
+## Reporting a vulnerability
+
+Use [GitHub's private vulnerability reporting](https://github.com/mors119/gh-mcp-router/security/advisories/new)
+for this repository. If private reporting is unavailable, contact the
+maintainer privately through GitHub. Please do not open a public issue for an
+unfixed vulnerability.
+
+Include the affected version or commit, a concise description, reproduction
+steps or a minimal proof of concept, and the impact. Redact tokens, cookies,
+authorization headers, private repository data, and personal configuration from
+all reports. Synthetic credentials and disposable repositories are preferred.
+
+Maintainers will acknowledge a report as soon as practical, investigate it,
+and coordinate disclosure after a fix or mitigation is available. Please allow
+time for validation before publishing details.
+
+## Credential-safety notes
+
+The router is a local developer process, not a public multi-tenant credential
+broker. It must not persist raw credentials, call `gh auth switch`, expose
+tokens in process arguments, or include secrets in logs and MCP responses. See
+[`docs/security.md`](docs/security.md) for the trust model and the limitations
+of best-effort in-memory secret protection.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,23 @@
+# Support
+
+Start with the documentation:
+
+- [Installation](docs/installation.md)
+- [Configuration](docs/configuration.md)
+- [MCP client integration](docs/mcp-client-integration.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Testing](docs/testing.md)
+- [Compatibility](docs/compatibility.md)
+
+For a reproducible bug, use the [bug report form](https://github.com/mors119/gh-mcp-router/issues/new?template=bug_report.yml).
+For a proposed behavior or feature, use the [feature request form](https://github.com/mors119/gh-mcp-router/issues/new?template=feature_request.yml).
+
+Before opening an issue, search existing issues and include the exact command,
+configuration shape, platform, router version, and relevant redacted output.
+Never include tokens, authorization headers, private keys, or unredacted
+`gh` output. Suspected vulnerabilities must follow
+[`SECURITY.md`](SECURITY.md), not a public issue.
+
+The project currently supports the platforms and upstream version listed in
+[`docs/compatibility.md`](docs/compatibility.md). Other platforms and MCP
+clients may work but are not verified support commitments.


### PR DESCRIPTION
## Summary

Add the baseline documentation and repository automation needed for open-source collaboration:

- contribution, code of conduct, security, support, and changelog docs;
- issue forms, pull request template, and CODEOWNERS;
- weekly Cargo and GitHub Actions Dependabot updates; and
- pull-request dependency review with a high-severity failure threshold.

README links the new project policies, while existing routing and credential behavior remains unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo build --locked`
- YAML parsing and `git diff --check`
